### PR TITLE
Add RateOrder types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ cabal.sandbox.config
 .stack-work/
 cabal.project.local
 .HTF/
-
+hscope.out

--- a/ballast.cabal
+++ b/ballast.cabal
@@ -28,6 +28,7 @@ library
                      , utf8-string
                      , time
                      , transformers
+                     , hspec
   default-language:    Haskell2010
 
 source-repository head

--- a/ballast.cabal
+++ b/ballast.cabal
@@ -26,6 +26,7 @@ library
                      , http-types
                      , text
                      , utf8-string
+                     , time
   default-language:    Haskell2010
 
 source-repository head

--- a/ballast.cabal
+++ b/ballast.cabal
@@ -27,6 +27,7 @@ library
                      , text
                      , utf8-string
                      , time
+                     , transformers
   default-language:    Haskell2010
 
 source-repository head

--- a/src/Ballast/Client.hs
+++ b/src/Ballast/Client.hs
@@ -26,11 +26,12 @@ sandboxUrl = "https://api.beta.shipwire.com/api/v3"
 
 -- | Generate a real-time shipping quote
 -- | https://www.shipwire.com/w/developers/rate/
-createRateResponse :: Maybe BSL.ByteString -> ShipWireRequest CreateRateResponse
-createRateResponse body = request
-  where request = mkShipWireRequest NHTM.methodPost url bod
-        url = (T.append sandboxUrl "/rate")
-        bod = body
+createRateRequest :: GetRate -> ShipWireRequest RateRequest
+createRateRequest getRate = request
+  where
+    request = mkShipWireRequest NHTM.methodPost url (Just $ encode getRate)
+    url = (T.append sandboxUrl "/rate")
+    bod = body
 
 dispatch
   :: (FromJSON (ShipWireReturn a))
@@ -52,5 +53,5 @@ dispatch (ShipWireRequest method endpoint body) = do
   return result
 
 -- Test case for dispatch:
--- let rateReq = createRateResponse (Just $ encode defaultRate)
+-- let rateReq = createRateRequest defaultGetRate
 -- dispatch rateReq

--- a/src/Ballast/Client.hs
+++ b/src/Ballast/Client.hs
@@ -24,6 +24,8 @@ baseUrl = "https://api.shipwire.com/api/v3"
 sandboxUrl :: Text
 sandboxUrl = "https://api.beta.shipwire.com/api/v3"
 
+-- | Generate a real-time shipping quote
+-- | https://www.shipwire.com/w/developers/rate/
 createRateResponse :: Maybe BSL.ByteString -> ShipWireRequest CreateRateResponse
 createRateResponse body = request
   where request = mkShipWireRequest NHTM.methodPost url bod

--- a/src/Ballast/Client.hs
+++ b/src/Ballast/Client.hs
@@ -40,7 +40,7 @@ main = do
     Just rateResult -> return rateResult
     Nothing -> error "Something went wrong"
 
-mkRequest :: NHTM.Method -> Text -> Maybe BSL.ByteString -> IO (Response BSL.ByteString)
+mkRequest :: Method -> Text -> Maybe BSL.ByteString -> IO Reply
 mkRequest rMethod endpoint body = do
   manager <- newManager tlsManagerSettings
   initialRequest <- parseRequest $ (T.unpack $ T.append (T.pack sandboxUrl) endpoint)

--- a/src/Ballast/Client.hs
+++ b/src/Ballast/Client.hs
@@ -1,6 +1,7 @@
 module Ballast.Client where
 
 import           Ballast.Types
+import           Data.Aeson                 (encode)
 import qualified Data.ByteString            as BS
 import qualified Data.ByteString.Char8      as BS8
 import qualified Data.ByteString.Lazy.Char8 as BSL
@@ -14,13 +15,18 @@ sandboxUrl = "https://api.beta.shipwire.com/api/v3"
 
 main :: IO ()
 main = do
-  manager <- newManager tlsManagerSettings
-  request <- parseRequest $ sandboxUrl ++ "/stock"
-  shipwireUser <- getEnv "SHIPWIRE_USER"
-  shipwirePass <- getEnv "SHIPWIRE_PASS"
-  let authorizedRequest =
-        applyBasicAuth (BS8.pack shipwireUser) (BS8.pack shipwirePass) request
-  response <- httpLbs authorizedRequest manager
-
-  putStrLn $ "The status code was: " ++ (show $ statusCode $ responseStatus response)
-  BSL.putStrLn $ responseBody response
+    manager <- newManager tlsManagerSettings
+    initialRequest <- parseRequest $ sandboxUrl ++ "/rate"
+    let request =
+            initialRequest
+            { method = (BS8.pack "POST")
+            , requestBody = RequestBodyLBS $ encode defaultRate
+            }
+    shipwireUser <- getEnv "SHIPWIRE_USER"
+    shipwirePass <- getEnv "SHIPWIRE_PASS"
+    let authorizedRequest =
+            applyBasicAuth (BS8.pack shipwireUser) (BS8.pack shipwirePass) request
+    response <- httpLbs authorizedRequest manager
+    putStrLn $
+        "The status code was: " ++ (show $ statusCode $ responseStatus response)
+    BSL.putStrLn $ responseBody response

--- a/src/Ballast/Client.hs
+++ b/src/Ballast/Client.hs
@@ -2,11 +2,11 @@ module Ballast.Client where
 
 import           Ballast.Types
 import qualified Data.ByteString            as BS
-import qualified Data.ByteString.Lazy.Char8 as BSL
 import qualified Data.ByteString.Char8      as BS8
+import qualified Data.ByteString.Lazy.Char8 as BSL
 import           Network.HTTP.Client
 import           Network.HTTP.Client.TLS
-import           Network.HTTP.Types.Status (statusCode)
+import           Network.HTTP.Types.Status  (statusCode)
 import           System.Environment
 
 baseUrl = "https://api.shipwire.com/api/v3"

--- a/src/Ballast/Client.hs
+++ b/src/Ballast/Client.hs
@@ -21,8 +21,8 @@ import           System.Environment
 baseUrl = "https://api.shipwire.com/api/v3"
 sandboxUrl = "https://api.beta.shipwire.com/api/v3"
 
-main :: IO RateResponse
-main = do
+exampleResponse :: IO RateResponse
+exampleResponse = do
   manager <- newManager tlsManagerSettings
   initialRequest <- parseRequest $ sandboxUrl ++ "/rate"
   let request =

--- a/src/Ballast/Client.hs
+++ b/src/Ballast/Client.hs
@@ -1,12 +1,20 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Ballast.Client where
 
 import           Ballast.Types
-import           Data.Aeson                 (decode, encode)
+import           Control.Monad.IO.Class
+import           Data.Aeson                 (decode, eitherDecode, encode)
+import           Data.Aeson.Types
 import qualified Data.ByteString            as BS
 import qualified Data.ByteString.Char8      as BS8
 import qualified Data.ByteString.Lazy.Char8 as BSL
+import           Data.Maybe                 (fromMaybe)
+import           Data.Text                  (Text)
+import qualified Data.Text                  as T
 import           Network.HTTP.Client
 import           Network.HTTP.Client.TLS
+import qualified Network.HTTP.Types.Method  as NHTM
 import           Network.HTTP.Types.Status  (statusCode)
 import           System.Environment
 
@@ -15,19 +23,34 @@ sandboxUrl = "https://api.beta.shipwire.com/api/v3"
 
 main :: IO RateResponse
 main = do
-    manager <- newManager tlsManagerSettings
-    initialRequest <- parseRequest $ sandboxUrl ++ "/rate"
-    let request =
-            initialRequest
-            { method = (BS8.pack "POST")
-            , requestBody = RequestBodyLBS $ encode defaultRate
-            }
-    shipwireUser <- getEnv "SHIPWIRE_USER"
-    shipwirePass <- getEnv "SHIPWIRE_PASS"
-    let authorizedRequest =
-            applyBasicAuth (BS8.pack shipwireUser) (BS8.pack shipwirePass) request
-    response <- httpLbs authorizedRequest manager
-    let mkResult = decode $ responseBody response
-    case mkResult of
-      Just rateResult -> return rateResult
-      Nothing -> error "Something went wrong"
+  manager <- newManager tlsManagerSettings
+  initialRequest <- parseRequest $ sandboxUrl ++ "/rate"
+  let request =
+        initialRequest
+        { method = (BS8.pack "POST")
+        , requestBody = RequestBodyLBS $ encode defaultRate
+        }
+  shipwireUser <- getEnv "SHIPWIRE_USER"
+  shipwirePass <- getEnv "SHIPWIRE_PASS"
+  let authorizedRequest =
+        applyBasicAuth (BS8.pack shipwireUser) (BS8.pack shipwirePass) request
+  response <- httpLbs authorizedRequest manager
+  let mkResult = decode $ responseBody response
+  case mkResult of
+    Just rateResult -> return rateResult
+    Nothing -> error "Something went wrong"
+
+mkRequest :: NHTM.Method -> Text -> Maybe BSL.ByteString -> IO (Response BSL.ByteString)
+mkRequest rMethod endpoint body = do
+  manager <- newManager tlsManagerSettings
+  initialRequest <- parseRequest $ (T.unpack $ T.append (T.pack sandboxUrl) endpoint)
+  let reqBody = RequestBodyLBS $ fromMaybe (BSL.pack "") body
+  let req = initialRequest { method = rMethod, requestBody = reqBody }
+  shipwireUser <- liftIO $ getEnv "SHIPWIRE_USER"
+  shipwirePass <- liftIO $ getEnv "SHIPWIRE_PASS"
+  let authorizedRequest =
+        applyBasicAuth (BS8.pack shipwireUser) (BS8.pack shipwirePass) req
+  httpLbs authorizedRequest manager
+
+-- Test case for mkRequest:
+-- mkRequest NHTM.methodPost (T.pack "/rate") (Just $ encode defaultRate)

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -5,6 +5,7 @@
 module Ballast.Types
        ( Username(..)
        , Password(..)
+       , defaultRate
        ) where
 
 import           Data.Aeson
@@ -93,7 +94,7 @@ data ShipTo =
 
 data Items =
   Items {
-    itemSku      :: Maybe SKU
+    itemSku      :: SKU
   , itemQuantity :: Integer
   } deriving (Eq, Generic, Show)
 
@@ -109,14 +110,16 @@ instance ToJSON ShipTo where
                        , omitNothingFields = True
                        }
 
+defaultRate = Rate defaultRateOptions defaultRateOrder
+
 defaultRateOrder = RateOrder defaultShipTo defaultItems
 
-defaultItems = Items (mkSku (T.pack "123456")) 5
+defaultItems = Items (SKU $ T.pack "Ballasttest") 1
 
 defaultShipTo =
-  ShipTo (AddressLine (T.pack "15 Bergen ave")) (AddressLine (T.pack ""))
-         (AddressLine (T.pack "")) (City (T.pack "Jersey City"))
-         (PostalCode (T.pack "123456")) (Region (T.pack "NJ")) (Country (T.pack "US"))
+  ShipTo (AddressLine (T.pack "6501 Railroad Avenue SE")) (AddressLine (T.pack "Room 315"))
+         (AddressLine (T.pack "")) (City (T.pack "Snoqualmie"))
+         (PostalCode (T.pack "85283")) (Region (T.pack "WA")) (Country (T.pack "US"))
          False False
 
 newtype AddressLine =

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -100,7 +100,6 @@ data Items =
 instance ToJSON Items where
   toEncoding = genericToEncoding defaultOptions
 
-
 instance ToJSON ShipTo where
   toJSON shipto =
     genericToJSON options shipto
@@ -121,35 +120,35 @@ defaultShipTo =
          False False
 
 newtype AddressLine =
-  AddressLine Text
+  AddressLine { unAddressLine :: Text }
   deriving (Eq, Generic, Show)
 
 instance ToJSON AddressLine where
   toEncoding = genericToEncoding defaultOptions
 
 newtype City =
-  City Text
+  City { unCity :: Text }
   deriving (Eq, Generic, Show)
 
 instance ToJSON City where
   toEncoding = genericToEncoding defaultOptions
 
 newtype PostalCode =
-  PostalCode Text
+  PostalCode { unPostalCode :: Text }
   deriving (Eq, Generic, Show)
 
 instance ToJSON PostalCode where
   toEncoding = genericToEncoding defaultOptions
 
 newtype Region =
-  Region Text
+  Region { unRegion :: Text }
   deriving (Eq, Generic, Show)
 
 instance ToJSON Region where
   toEncoding = genericToEncoding defaultOptions
 
 newtype Country =
-  Country Text
+  Country { unCountry :: Text }
   deriving (Eq, Generic, Show)
 
 instance ToJSON Country where

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -99,7 +99,13 @@ data Items =
   } deriving (Eq, Generic, Show)
 
 instance ToJSON Items where
-  toEncoding = genericToEncoding defaultOptions
+  toJSON items =
+    genericToJSON options items
+    where
+      options =
+        defaultOptions { fieldLabelModifier = downcaseHead . drop 4
+                       , omitNothingFields = True
+                       }
 
 instance ToJSON ShipTo where
   toJSON shipto =

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -35,7 +35,13 @@ mkSku sku
   | otherwise = Just (SKU sku)
 
 instance ToJSON SKU where
-  toEncoding = genericToEncoding defaultOptions
+  -- toEncoding = genericToEncoding defaultOptions
+  -- toJSON (SKU sku) = object ["sku" .= sku]
+  toJSON sku =
+    genericToJSON options sku
+    where
+      options =
+        defaultOptions { unwrapUnaryRecords = True }
 
 -- max 16 characters
 -- haskellbookskuty
@@ -81,15 +87,15 @@ instance ToJSON RateOrder where
 
 data ShipTo =
   ShipTo {
-    shipToAddressLine1 :: AddressLine
-  , shipToAddressLine2 :: AddressLine
-  , shipToAddressLine3 :: AddressLine
+    shipToAddress1     :: AddressLine
+  , shipToAddress2     :: AddressLine
+  , shipToAddress3     :: AddressLine
   , shipToCity         :: City
   , shipToPostalCode   :: PostalCode
   , shipToRegion       :: Region
   , shipToCountry      :: Country
-  , shipToIsCommercial :: Bool
-  , shipToIsPoBox      :: Bool
+  , shipToIsCommercial :: Integer
+  , shipToIsPoBox      :: Integer
   } deriving (Eq, Generic, Show)
 
 type Items = [ItemInfo]
@@ -113,48 +119,48 @@ defaultRate = Rate defaultRateOptions defaultRateOrder
 
 defaultRateOrder = RateOrder defaultShipTo defaultItems
 
-defaultItems = [ItemInfo ((SKU $ T.pack "Ballasttest"), 1)]
+defaultItems = [ItemInfo ((SKU "Ballasttest"), 1)]
 
 defaultShipTo =
-  ShipTo (AddressLine (T.pack "6501 Railroad Avenue SE")) (AddressLine (T.pack "Room 315"))
-         (AddressLine (T.pack "")) (City (T.pack "Snoqualmie"))
-         (PostalCode (T.pack "85283")) (Region (T.pack "WA")) (Country (T.pack "US"))
-         False False
+  ShipTo (AddressLine "6501 Railroad Avenue SE") (AddressLine "Room 315")
+         (AddressLine "") (City "Snoqualmie")
+         (PostalCode "85283") (Region "WA") (Country "US")
+         1 0
 
 newtype AddressLine =
   AddressLine { unAddressLine :: Text }
-  deriving (Eq, Generic, Show)
+  deriving (Eq, Show)
 
 instance ToJSON AddressLine where
-  toEncoding = genericToEncoding defaultOptions
+  toJSON (AddressLine a) = toJSON a
 
 newtype City =
   City { unCity :: Text }
-  deriving (Eq, Generic, Show)
+  deriving (Eq, Show)
 
 instance ToJSON City where
-  toEncoding = genericToEncoding defaultOptions
+  toJSON (City c) = toJSON c
 
 newtype PostalCode =
   PostalCode { unPostalCode :: Text }
-  deriving (Eq, Generic, Show)
+  deriving (Eq, Show)
 
 instance ToJSON PostalCode where
-  toEncoding = genericToEncoding defaultOptions
+  toJSON (PostalCode p) = toJSON p
 
 newtype Region =
   Region { unRegion :: Text }
-  deriving (Eq, Generic, Show)
+  deriving (Eq, Show)
 
 instance ToJSON Region where
-  toEncoding = genericToEncoding defaultOptions
+  toJSON (Region r) = toJSON r
 
 newtype Country =
   Country { unCountry :: Text }
-  deriving (Eq, Generic, Show)
+  deriving (Eq, Show)
 
 instance ToJSON Country where
-  toEncoding = genericToEncoding defaultOptions
+  toJSON (Country c) = toJSON c
 
 downcaseHead :: [Char] -> [Char]
 downcaseHead [] = []

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -1,21 +1,21 @@
-{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE RecordWildCards   #-}
 
 module Ballast.Types
        ( Username(..)
        , Password(..)
        ) where
 
-import Data.Aeson
-import Data.Aeson.Types
-import Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
+import           Data.Aeson
+import           Data.Aeson.Types
+import           Data.ByteString            (ByteString)
+import qualified Data.ByteString            as BS
 import qualified Data.ByteString.Lazy.Char8 as BSL
-import qualified Data.Char as DC
-import Data.Text (Text)
-import qualified Data.Text as T
-import GHC.Generics
+import qualified Data.Char                  as DC
+import           Data.Text                  (Text)
+import qualified Data.Text                  as T
+import           GHC.Generics
 
 -- | Username type used for HTTP Basic authentication.
 newtype Username = Username { username :: ByteString } deriving (Read, Show, Eq)
@@ -39,6 +39,7 @@ mkSku sku
 data Rate =
   Rate {
     rateOptions :: RateOptions
+  , rateOrder   :: RateOrder
   } deriving (Eq, Generic, Show)
 
 instance ToJSON Rate where
@@ -52,12 +53,89 @@ instance ToJSON Rate where
 
 data RateOptions =
   RateOptions {
-    rateOptionCurrency :: Currency
-  , rateOptionGroupBy :: GroupBy
-  , rateOptionCanSplit :: Integer
+    rateOptionCurrency      :: Currency
+  , rateOptionGroupBy       :: GroupBy
+  , rateOptionCanSplit      :: Integer
   , rateOptionWarehouseArea :: WarehouseArea
-  , rateOptionChannelName :: Maybe Text
+  , rateOptionChannelName   :: Maybe Text
   } deriving (Eq, Generic, Show)
+
+data RateOrder =
+  RateOrder {
+    rateOrderShipTo :: ShipTo
+  } deriving (Eq, Generic, Show)
+
+instance ToJSON RateOrder where
+  toJSON order =
+    genericToJSON options order
+    where
+      options =
+        defaultOptions { fieldLabelModifier = downcaseHead . drop 9
+                       , omitNothingFields = True
+                       }
+
+data ShipTo =
+  ShipTo {
+    shipToAddressLine1 :: AddressLine
+  , shipToAddressLine2 :: AddressLine
+  , shipToAddressLine3 :: AddressLine
+  , shipToCity         :: City
+  , shipToPostalCode   :: PostalCode
+  , shipToRegion       :: Region
+  , shipToCountry      :: Country
+  , shipToIsCommercial :: Bool
+  , shipToIsPoBox      :: Bool
+  } deriving (Eq, Generic, Show)
+
+instance ToJSON ShipTo where
+  toJSON shipto =
+    genericToJSON options shipto
+    where
+      options =
+        defaultOptions { fieldLabelModifier = downcaseHead . drop 6
+                       , omitNothingFields = True
+                       }
+
+defaultShipTo =
+  ShipTo (AddressLine (T.pack "15 Bergen ave")) (AddressLine (T.pack ""))
+         (AddressLine (T.pack "")) (City (T.pack "Jersey City"))
+         (PostalCode (T.pack "123456")) (Region (T.pack "US")) (Country (T.pack "US"))
+         False False
+
+newtype AddressLine =
+  AddressLine Text
+  deriving (Eq, Generic, Show)
+
+instance ToJSON AddressLine where
+  toEncoding = genericToEncoding defaultOptions
+
+newtype City =
+  City Text
+  deriving (Eq, Generic, Show)
+
+instance ToJSON City where
+  toEncoding = genericToEncoding defaultOptions
+
+newtype PostalCode =
+  PostalCode Text
+  deriving (Eq, Generic, Show)
+
+instance ToJSON PostalCode where
+  toEncoding = genericToEncoding defaultOptions
+
+newtype Region =
+  Region Text
+  deriving (Eq, Generic, Show)
+
+instance ToJSON Region where
+  toEncoding = genericToEncoding defaultOptions
+
+newtype Country =
+  Country Text
+  deriving (Eq, Generic, Show)
+
+instance ToJSON Country where
+  toEncoding = genericToEncoding defaultOptions
 
 downcaseHead :: [Char] -> [Char]
 downcaseHead [] = []

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -3,11 +3,11 @@
 {-# LANGUAGE RecordWildCards   #-}
 
 module Ballast.Types
-       ( Username(..)
-       , Password(..)
-       , RateResponse(..)
-       , defaultRate
-       ) where
+  ( Username(..)
+  , Password(..)
+  , RateResponse(..)
+  , defaultRate
+  ) where
 
 import           Control.Monad              (mzero)
 import           Data.Aeson
@@ -23,14 +23,18 @@ import           Data.Time.Clock            (UTCTime)
 import           GHC.Generics
 
 -- | Username type used for HTTP Basic authentication.
-newtype Username = Username { username :: ByteString } deriving (Read, Show, Eq)
+newtype Username = Username
+  { username :: ByteString
+  } deriving (Read, Show, Eq)
 
 -- | Password type used for HTTP Basic authentication.
-newtype Password = Password { password :: ByteString } deriving (Read, Show, Eq)
+newtype Password = Password
+  { password :: ByteString
+  } deriving (Read, Show, Eq)
 
-newtype SKU =
-  SKU { unSku :: Text }
-  deriving (Eq, Generic, Show)
+newtype SKU = SKU
+  { sku :: Text
+  } deriving (Eq, Generic, Show)
 
 mkSku :: Text -> Maybe SKU
 mkSku sku
@@ -39,57 +43,53 @@ mkSku sku
   | otherwise = Just (SKU sku)
 
 instance ToJSON SKU where
-  toJSON sku =
-    genericToJSON options sku
+  toJSON sku = genericToJSON options sku
     where
       options =
-        defaultOptions { unwrapUnaryRecords = True }
+        defaultOptions
+        { unwrapUnaryRecords = True
+        }
 
 -- max 16 characters
 -- haskellbookskuty
-
-data Rate =
-  Rate {
-    rateOptions :: RateOptions
+data Rate = Rate
+  { rateOptions :: RateOptions
   , rateOrder   :: RateOrder
   } deriving (Eq, Generic, Show)
 
 instance ToJSON Rate where
-  toJSON rate =
-    genericToJSON options rate
+  toJSON rate = genericToJSON options rate
     where
       options =
-        defaultOptions { fieldLabelModifier = downcaseHead . drop 4
-                       , omitNothingFields = True
-                       }
+        defaultOptions
+        { fieldLabelModifier = downcaseHead . drop 4
+        , omitNothingFields = True
+        }
 
-data RateOptions =
-  RateOptions {
-    rateOptionCurrency      :: Currency
+data RateOptions = RateOptions
+  { rateOptionCurrency      :: Currency
   , rateOptionGroupBy       :: GroupBy
   , rateOptionCanSplit      :: Integer
   , rateOptionWarehouseArea :: WarehouseArea
   , rateOptionChannelName   :: Maybe Text
   } deriving (Eq, Generic, Show)
 
-data RateOrder =
-  RateOrder {
-    rateOrderShipTo :: ShipTo
+data RateOrder = RateOrder
+  { rateOrderShipTo :: ShipTo
   , rateOrderItems  :: Items
   } deriving (Eq, Generic, Show)
 
 instance ToJSON RateOrder where
-  toJSON order =
-    genericToJSON options order
+  toJSON order = genericToJSON options order
     where
       options =
-        defaultOptions { fieldLabelModifier = downcaseHead . drop 9
-                       , omitNothingFields = True
-                       }
+        defaultOptions
+        { fieldLabelModifier = downcaseHead . drop 9
+        , omitNothingFields = True
+        }
 
-data ShipTo =
-  ShipTo {
-    shipToAddress1     :: AddressLine
+data ShipTo = ShipTo
+  { shipToAddress1     :: AddressLine
   , shipToAddress2     :: AddressLine
   , shipToAddress3     :: AddressLine
   , shipToCity         :: City
@@ -100,20 +100,29 @@ data ShipTo =
   , shipToIsPoBox      :: IsPoBox
   } deriving (Eq, Generic, Show)
 
-data IsCommercial = Commercial | NotCommercial deriving (Eq, Generic, Show)
+data IsCommercial
+  = Commercial
+  | NotCommercial
+  deriving (Eq, Generic, Show)
 
 instance ToJSON IsCommercial where
   toJSON Commercial = Number 1
   toJSON NotCommercial = Number 0
 
-data IsPoBox = PoBox | NotPoBox deriving (Eq, Generic, Show)
+data IsPoBox
+  = PoBox
+  | NotPoBox
+  deriving (Eq, Generic, Show)
 
 instance ToJSON IsPoBox where
   toJSON PoBox = Number 1
   toJSON NotPoBox = Number 0
 
 type Items = [ItemInfo]
-data ItemInfo = ItemInfo (SKU, Quantity) deriving (Eq, Show)
+
+data ItemInfo =
+  ItemInfo (SKU, Quantity)
+  deriving (Eq, Show)
 
 instance ToJSON ItemInfo where
   toJSON (ItemInfo (sku, q)) = object ["sku" .= sku, "quantity" .= q]
@@ -121,13 +130,13 @@ instance ToJSON ItemInfo where
 type Quantity = Integer
 
 instance ToJSON ShipTo where
-  toJSON shipto =
-    genericToJSON options shipto
+  toJSON shipto = genericToJSON options shipto
     where
       options =
-        defaultOptions { fieldLabelModifier = downcaseHead . drop 6
-                       , omitNothingFields = True
-                       }
+        defaultOptions
+        { fieldLabelModifier = downcaseHead . drop 6
+        , omitNothingFields = True
+        }
 
 defaultRate = Rate defaultRateOptions defaultRateOrder
 
@@ -136,82 +145,91 @@ defaultRateOrder = RateOrder defaultShipTo defaultItems
 defaultItems = [ItemInfo ((SKU "Ballasttest"), 1)]
 
 defaultShipTo =
-  ShipTo (AddressLine "6501 Railroad Avenue SE") (AddressLine "Room 315")
-         (AddressLine "") (City "Snoqualmie")
-         (PostalCode "85283") (Region "WA") (Country "US")
-         Commercial NotPoBox
+  ShipTo
+    (AddressLine "6501 Railroad Avenue SE")
+    (AddressLine "Room 315")
+    (AddressLine "")
+    (City "Snoqualmie")
+    (PostalCode "85283")
+    (Region "WA")
+    (Country "US")
+    Commercial
+    NotPoBox
 
-newtype AddressLine =
-  AddressLine { unAddressLine :: Text }
-  deriving (Eq, Generic, Show)
---
+newtype AddressLine = AddressLine
+  { addressLine :: Text
+  } deriving (Eq, Generic, Show)
+
 instance ToJSON AddressLine where
-  toJSON address =
-    genericToJSON options address
+  toJSON address = genericToJSON options address
     where
       options =
-        defaultOptions { unwrapUnaryRecords = True }
+        defaultOptions
+        { unwrapUnaryRecords = True
+        }
 
-newtype City =
-  City { unCity :: Text }
-  deriving (Eq, Generic, Show)
+newtype City = City
+  { city :: Text
+  } deriving (Eq, Generic, Show)
 
 instance ToJSON City where
-  toJSON city =
-    genericToJSON options city
+  toJSON city = genericToJSON options city
     where
       options =
-        defaultOptions { unwrapUnaryRecords = True }
+        defaultOptions
+        { unwrapUnaryRecords = True
+        }
 
-newtype PostalCode =
-  PostalCode { unPostalCode :: Text }
-  deriving (Eq, Generic, Show)
+newtype PostalCode = PostalCode
+  { postalCode :: Text
+  } deriving (Eq, Generic, Show)
 
 instance ToJSON PostalCode where
-  toJSON code =
-    genericToJSON options code
+  toJSON code = genericToJSON options code
     where
       options =
-        defaultOptions { unwrapUnaryRecords = True }
+        defaultOptions
+        { unwrapUnaryRecords = True
+        }
 
-newtype Region =
-  Region { unRegion :: Text }
-  deriving (Eq, Generic, Show)
+newtype Region = Region
+  { region :: Text
+  } deriving (Eq, Generic, Show)
 
 instance ToJSON Region where
-  toJSON region =
-    genericToJSON options region
+  toJSON region = genericToJSON options region
     where
       options =
-        defaultOptions { unwrapUnaryRecords = True }
+        defaultOptions
+        { unwrapUnaryRecords = True
+        }
 
-newtype Country =
-  Country { unCountry :: Text }
-  deriving (Eq, Generic, Show)
+newtype Country = Country
+  { country :: Text
+  } deriving (Eq, Generic, Show)
 
 instance ToJSON Country where
-  toJSON country =
-    genericToJSON options country
+  toJSON country = genericToJSON options country
     where
       options =
-        defaultOptions { unwrapUnaryRecords = True }
+        defaultOptions
+        { unwrapUnaryRecords = True
+        }
 
 downcaseHead :: [Char] -> [Char]
 downcaseHead [] = []
-downcaseHead (x:xs) =
-  (DC.toLower x) : xs
+downcaseHead (x:xs) = (DC.toLower x) : xs
 
 instance ToJSON RateOptions where
-  toJSON ro =
-    genericToJSON options ro
+  toJSON ro = genericToJSON options ro
     where
       options =
-        defaultOptions { fieldLabelModifier = downcaseHead . drop 10
-                       , omitNothingFields = True
-                       }
+        defaultOptions
+        { fieldLabelModifier = downcaseHead . drop 10
+        , omitNothingFields = True
+        }
 
-defaultRateOptions =
-  RateOptions USD GroupByAll 1 WarehouseAreaUS Nothing
+defaultRateOptions = RateOptions USD GroupByAll 1 WarehouseAreaUS Nothing
 
 data Currency =
   USD
@@ -220,19 +238,22 @@ data Currency =
 instance ToJSON Currency where
   toJSON USD = String "USD"
 
-tshow :: Show a => a -> Text
+tshow
+  :: Show a
+  => a -> Text
 tshow = T.pack . show
 
 omitNulls :: [(Text, Value)] -> Value
-omitNulls = object . filter notNull where
-  notNull (_, Null)      = False
-  -- notNull (_, Array a) = (not . V.null) a
-  notNull _              = True
+omitNulls = object . filter notNull
+  where
+    notNull (_, Null) = False
+    -- notNull (_, Array a) = (not . V.null) a
+    notNull _ = True
 
-data GroupBy =
-      GroupByAll
-    | GroupByWarehouse
-    deriving (Eq, Generic, Show)
+data GroupBy
+  = GroupByAll
+  | GroupByWarehouse
+  deriving (Eq, Generic, Show)
 
 instance ToJSON GroupBy where
   toJSON GroupByAll = String "all"
@@ -240,8 +261,9 @@ instance ToJSON GroupBy where
 
 instance FromJSON GroupBy where
   parseJSON = withText "groupBy" parse
-    where parse "all" = pure GroupByAll
-          parse "warehouse" = pure GroupByWarehouse
+    where
+      parse "all" = pure GroupByAll
+      parse "warehouse" = pure GroupByWarehouse
 
 data WarehouseArea =
   WarehouseAreaUS
@@ -258,9 +280,8 @@ instance ToJSON WarehouseArea where
 --     Right info -> return info
 --     Left err -> error err
 
-data RateResponse =
-  RateResponse {
-    rateResponseStatus           :: Integer
+data RateResponse = RateResponse
+  { rateResponseStatus           :: Integer
   , rateResponseMessage          :: Text
   , rateResponseWarnings         :: Maybe [Warnings]
   , rateResponseResourceLocation :: Maybe Text
@@ -268,115 +289,127 @@ data RateResponse =
   } deriving (Eq, Generic, Show)
 
 instance FromJSON RateResponse where
-  parseJSON rr =
-    genericParseJSON options rr
+  parseJSON rr = genericParseJSON options rr
     where
       options =
-        defaultOptions { fieldLabelModifier = downcaseHead . drop 12 }
+        defaultOptions
+        { fieldLabelModifier = downcaseHead . drop 12
+        }
 
-data Warnings =
-  Warnings {
-    warningsCode    :: Text
+data Warnings = Warnings
+  { warningsCode    :: Text
   , warningsMessage :: Text
   , warningsType    :: WarningType
   } deriving (Eq, Generic, Show)
 
-data WarningType =
-    WarningsWarning
+data WarningType
+  = WarningsWarning
   | WarningsError
   deriving (Eq, Generic, Show)
 
 instance FromJSON WarningType where
   parseJSON = withText "warningType" parse
-    where parse "warning" = pure WarningsWarning
-          parse "error" = pure WarningsError
+    where
+      parse "warning" = pure WarningsWarning
+      parse "error" = pure WarningsError
 
 instance FromJSON Warnings where
-  parseJSON w =
-    genericParseJSON options w
+  parseJSON w = genericParseJSON options w
     where
       options =
-        defaultOptions { fieldLabelModifier = downcaseHead . drop 8 }
+        defaultOptions
+        { fieldLabelModifier = downcaseHead . drop 8
+        }
 
-data Resource =
-  Resource {
-    resourceGroupBy :: GroupBy
+data Resource = Resource
+  { resourceGroupBy :: GroupBy
   , resourceRates   :: Rates
   } deriving (Eq, Generic, Show)
 
 instance FromJSON Resource where
-  parseJSON res =
-    genericParseJSON options res
+  parseJSON res = genericParseJSON options res
     where
       options =
-        defaultOptions { fieldLabelModifier = downcaseHead . drop 8 }
+        defaultOptions
+        { fieldLabelModifier = downcaseHead . drop 8
+        }
 
-newtype Rates =
-  Rates {
-    rateServiceOptions :: [ServiceOptions]
+newtype Rates = Rates
+  { rateServiceOptions :: [ServiceOptions]
   } deriving (Eq, Generic, Show)
 
 instance FromJSON Rates where
-  parseJSON rates =
-    genericParseJSON options rates
+  parseJSON rates = genericParseJSON options rates
     where
       options =
-        defaultOptions { fieldLabelModifier = downcaseHead . drop 4
-                       , unwrapUnaryRecords = True
-                       }
+        defaultOptions
+        { fieldLabelModifier = downcaseHead . drop 4
+        , unwrapUnaryRecords = True
+        }
 
-data ServiceOptions =
-  ServiceOptions {
-    serviceOptions  :: [ServiceOption]
-  , groupId         :: Integer
-  , groupExternalId :: Maybe Text
+data ServiceOptions = ServiceOptions
+  { sOptsServiceOptions  :: [ServiceOption]
+  , sOptsGroupId         :: Integer
+  , sOptsGroupExternalId :: Maybe Text
   } deriving (Eq, Generic, Show)
 
 instance FromJSON ServiceOptions where
-  parseJSON = genericParseJSON defaultOptions
+  parseJSON sop = genericParseJSON options sop
+    where
+      options =
+        defaultOptions
+        { fieldLabelModifier = downcaseHead . drop 5
+        }
 
-data ServiceOption =
-  ServiceOption {
-    serviceLevelCode :: Text
-  , serviceLevelName :: Text
-  , shipments        :: [Shipment]
+data ServiceOption = ServiceOption
+  { sOptServiceLevelCode :: Text
+  , sOptServiceLevelName :: Text
+  , sOptShipments        :: [Shipment]
   } deriving (Eq, Generic, Show)
 
 instance FromJSON ServiceOption where
-  parseJSON = genericParseJSON defaultOptions
+  parseJSON sopt = genericParseJSON options sopt
+    where
+      options =
+        defaultOptions
+        { fieldLabelModifier = downcaseHead . drop 4
+        }
 
-data Shipment =
-  Shipment {
-    warehouseName           :: Text
-  , carrier                 :: Carrier
-  , cost                    :: Cost
-  , subtotals               :: [Subtotal]
-  , pieces                  :: [Piece]
-  , expectedShipDate        :: Maybe UTCTime
-  , expectedDeliveryDateMin :: Maybe UTCTime
-  , expectedDeliveryDateMax :: Maybe UTCTime
+data Shipment = Shipment
+  { shipmentWarehouseName           :: Text
+  , shipmentCarrier                 :: Carrier
+  , shipmentCost                    :: Cost
+  , shipmentSubtotals               :: [Subtotal]
+  , shipmentPieces                  :: [Piece]
+  , shipmentExpectedShipDate        :: Maybe UTCTime
+  , shipmentExpectedDeliveryDateMin :: Maybe UTCTime
+  , shipmentExpectedDeliveryDateMax :: Maybe UTCTime
   } deriving (Eq, Generic, Show)
 
 instance FromJSON Shipment where
-  parseJSON = genericParseJSON defaultOptions
+  parseJSON sh = genericParseJSON options sh
+    where
+      options =
+        defaultOptions
+        { fieldLabelModifier = downcaseHead . drop 8
+        }
 
-data Carrier =
-  Carrier {
-    carrierCode       :: Text
+data Carrier = Carrier
+  { carrierCode       :: Text
   , carrierName       :: Text
   , carrierProperties :: [Text]
   } deriving (Eq, Generic, Show)
 
 instance FromJSON Carrier where
-  parseJSON car =
-    genericParseJSON options car
+  parseJSON car = genericParseJSON options car
     where
       options =
-        defaultOptions { fieldLabelModifier = downcaseHead . drop 7 }
+        defaultOptions
+        { fieldLabelModifier = downcaseHead . drop 7
+        }
 
-data Cost =
-  Cost {
-    costCurrency         :: Text
+data Cost = Cost
+  { costCurrency         :: Text
   , costType             :: Text
   , costName             :: Text
   , costAmount           :: Centi
@@ -386,15 +419,15 @@ data Cost =
   } deriving (Eq, Generic, Show)
 
 instance FromJSON Cost where
-  parseJSON cos =
-    genericParseJSON options cos
+  parseJSON cos = genericParseJSON options cos
     where
       options =
-        defaultOptions { fieldLabelModifier = downcaseHead . drop 4 }
+        defaultOptions
+        { fieldLabelModifier = downcaseHead . drop 4
+        }
 
-data Subtotal =
-  Subtotal {
-    subtotalCurrency         :: Text
+data Subtotal = Subtotal
+  { subtotalCurrency         :: Text
   , sbutotalType             :: Text
   , subtotalName             :: Text
   , subtotalAmount           :: Centi
@@ -404,15 +437,15 @@ data Subtotal =
   } deriving (Eq, Generic, Show)
 
 instance FromJSON Subtotal where
-  parseJSON sub =
-    genericParseJSON options sub
+  parseJSON sub = genericParseJSON options sub
     where
       options =
-        defaultOptions { fieldLabelModifier = downcaseHead . drop 8 }
+        defaultOptions
+        { fieldLabelModifier = downcaseHead . drop 8
+        }
 
-data Piece =
-  Piece {
-    pieceLength     :: PieceLength
+data Piece = Piece
+  { pieceLength     :: PieceLength
   , pieceWidth      :: PieceWidth
   , pieceHeight     :: PieceHeight
   , pieceWeight     :: PieceWeight
@@ -421,50 +454,89 @@ data Piece =
   } deriving (Eq, Generic, Show)
 
 instance FromJSON Piece where
-  parseJSON pi =
-    genericParseJSON options pi
+  parseJSON pi = genericParseJSON options pi
     where
       options =
-        defaultOptions { fieldLabelModifier = downcaseHead . drop 5 }
+        defaultOptions
+        { fieldLabelModifier = downcaseHead . drop 5
+        }
 
-
-data PieceLength =
-  PieceLength {
-    amount :: Integer
-  , units  :: Text
+data PieceLength = PieceLength
+  { pieceLengthAmount :: Integer
+  , pieceLengthUnits  :: Text
   } deriving (Eq, Generic, Show)
 
 instance FromJSON PieceLength where
-  parseJSON = genericParseJSON defaultOptions
+  parseJSON pl = genericParseJSON options pl
+    where
+      options =
+        defaultOptions
+        { fieldLabelModifier = downcaseHead . drop 11
+        }
 
-type PieceWidth = PieceLength
-type PieceHeight = PieceLength
+data PieceWidth = PieceWidth
+  { pieceWidthAmount :: Integer
+  , pieceWidthUnits  :: Text
+  } deriving (Eq, Generic, Show)
 
-data PieceWeight =
-  PieceWeight {
-    pwAmount :: Double
-  , pwUnits  :: Text
-  , pwType   :: Text
+instance FromJSON PieceWidth where
+  parseJSON pw = genericParseJSON options pw
+    where
+      options =
+        defaultOptions
+        { fieldLabelModifier = downcaseHead . drop 10
+        }
+
+data PieceHeight = PieceHeight
+  { pieceHeightAmount :: Integer
+  , pieceHeightUnits  :: Text
+  } deriving (Eq, Generic, Show)
+
+instance FromJSON PieceHeight where
+  parseJSON ph = genericParseJSON options ph
+    where
+      options =
+        defaultOptions
+        { fieldLabelModifier = downcaseHead . drop 11
+        }
+
+data PieceWeight = PieceWeight
+  { pieceWeightAmount :: Double
+  , pieceWeightUnits  :: Text
+  , pieceWeightType   :: Text
   } deriving (Eq, Generic, Show)
 
 instance FromJSON PieceWeight where
-  parseJSON pw =
-    genericParseJSON options pw
+  parseJSON pw = genericParseJSON options pw
     where
       options =
-        defaultOptions { fieldLabelModifier = downcaseHead . drop 2 }
+        defaultOptions
+        { fieldLabelModifier = downcaseHead . drop 11
+        }
 
-type PieceSubWeight = PieceWeight
+data PieceSubWeight = PieceSubWeight
+  { pieceSubWeightAmount :: Double
+  , pieceSubWeightUnits  :: Text
+  , pieceSubWeightType   :: Text
+  } deriving (Eq, Generic, Show)
 
-data PieceContent =
-  PieceContent {
-    pcSku      :: Text
-  , pcQuantity :: Integer
+instance FromJSON PieceSubWeight where
+  parseJSON psw = genericParseJSON options psw
+    where
+      options =
+        defaultOptions
+        { fieldLabelModifier = downcaseHead . drop 14
+        }
+
+data PieceContent = PieceContent
+  { pieceContentSku      :: Text
+  , pieceContentQuantity :: Integer
   } deriving (Eq, Generic, Show)
 
 instance FromJSON PieceContent where
-  parseJSON pc =
-    genericParseJSON options pc
+  parseJSON pc = genericParseJSON options pc
     where
       options =
-        defaultOptions { fieldLabelModifier = downcaseHead . drop 2 }
+        defaultOptions
+        { fieldLabelModifier = downcaseHead . drop 12
+        }

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -25,13 +25,16 @@ newtype Password = Password { password :: ByteString } deriving (Read, Show, Eq)
 
 newtype SKU =
   SKU { unSku :: Text }
-  deriving (Eq, Show)
+  deriving (Eq, Generic, Show)
 
 mkSku :: Text -> Maybe SKU
 mkSku sku
   | T.length sku > 16 = Nothing
   | T.length sku < 1 = Nothing
   | otherwise = Just (SKU sku)
+
+instance ToJSON SKU where
+  toEncoding = genericToEncoding defaultOptions
 
 -- max 16 characters
 -- haskellbookskuty
@@ -63,6 +66,7 @@ data RateOptions =
 data RateOrder =
   RateOrder {
     rateOrderShipTo :: ShipTo
+  , rateOrderItems  :: Items
   } deriving (Eq, Generic, Show)
 
 instance ToJSON RateOrder where
@@ -87,6 +91,16 @@ data ShipTo =
   , shipToIsPoBox      :: Bool
   } deriving (Eq, Generic, Show)
 
+data Items =
+  Items {
+    itemSku      :: Maybe SKU
+  , itemQuantity :: Integer
+  } deriving (Eq, Generic, Show)
+
+instance ToJSON Items where
+  toEncoding = genericToEncoding defaultOptions
+
+
 instance ToJSON ShipTo where
   toJSON shipto =
     genericToJSON options shipto
@@ -96,10 +110,14 @@ instance ToJSON ShipTo where
                        , omitNothingFields = True
                        }
 
+defaultRateOrder = RateOrder defaultShipTo defaultItems
+
+defaultItems = Items (mkSku (T.pack "123456")) 5
+
 defaultShipTo =
   ShipTo (AddressLine (T.pack "15 Bergen ave")) (AddressLine (T.pack ""))
          (AddressLine (T.pack "")) (City (T.pack "Jersey City"))
-         (PostalCode (T.pack "123456")) (Region (T.pack "US")) (Country (T.pack "US"))
+         (PostalCode (T.pack "123456")) (Region (T.pack "NJ")) (Country (T.pack "US"))
          False False
 
 newtype AddressLine =

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -28,6 +28,7 @@ module Ballast.Types
   , ServiceOptions(..)
   , Resource(..)
   , ShipWireRequest(..)
+  , CreateRateResponse
   , mkShipWireRequest
   , ShipWireReturn(..)
   , defaultRate
@@ -604,5 +605,5 @@ mkShipWireRequest m e b = ShipWireRequest m e b
 
 type family ShipWireReturn a :: *
 
--- data CreateRateResponse
-type instance ShipWireReturn RateResponse = RateResponse
+data CreateRateResponse
+type instance ShipWireReturn CreateRateResponse = RateResponse

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -92,20 +92,13 @@ data ShipTo =
   , shipToIsPoBox      :: Bool
   } deriving (Eq, Generic, Show)
 
-data Items =
-  Items {
-    itemSku      :: SKU
-  , itemQuantity :: Integer
-  } deriving (Eq, Generic, Show)
+type Items = [ItemInfo]
+data ItemInfo = ItemInfo (SKU, Quantity) deriving (Eq, Show)
 
-instance ToJSON Items where
-  toJSON items =
-    genericToJSON options items
-    where
-      options =
-        defaultOptions { fieldLabelModifier = downcaseHead . drop 4
-                       , omitNothingFields = True
-                       }
+instance ToJSON ItemInfo where
+  toJSON (ItemInfo (sku, q)) = object ["sku" .= sku, "quantity" .= q]
+
+type Quantity = Integer
 
 instance ToJSON ShipTo where
   toJSON shipto =
@@ -120,7 +113,7 @@ defaultRate = Rate defaultRateOptions defaultRateOrder
 
 defaultRateOrder = RateOrder defaultShipTo defaultItems
 
-defaultItems = Items (SKU $ T.pack "Ballasttest") 1
+defaultItems = [ItemInfo ((SKU $ T.pack "Ballasttest"), 1)]
 
 defaultShipTo =
   ShipTo (AddressLine (T.pack "6501 Railroad Avenue SE")) (AddressLine (T.pack "Room 315"))

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -5,7 +5,27 @@
 module Ballast.Types
   ( Username(..)
   , Password(..)
+  , Rate(..)
   , RateResponse(..)
+  , RateOptions(..)
+  , Currency(..)
+  , GroupBy(..)
+  , WarehouseArea(..)
+  , RateOrder(..)
+  , Items(..)
+  , ItemInfo(..)
+  , ShipTo(..)
+  , SKU(..)
+  , AddressLine(..)
+  , City(..)
+  , PostalCode(..)
+  , Region(..)
+  , Country(..)
+  , IsCommercial(..)
+  , IsPoBox(..)
+  , Rates(..)
+  , ServiceOptions(..)
+  , Resource(..)
   , defaultRate
   , Reply
   , Method
@@ -353,7 +373,7 @@ instance FromJSON Rates where
 
 data ServiceOptions = ServiceOptions
   { sOptsServiceOptions  :: [ServiceOption]
-  , sOptsGroupId         :: Integer
+  , sOptsGroupId         :: Maybe Integer
   , sOptsGroupExternalId :: Maybe Text
   } deriving (Eq, Generic, Show)
 

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -7,6 +7,8 @@ module Ballast.Types
   , Password(..)
   , RateResponse(..)
   , defaultRate
+  , Reply
+  , Method
   ) where
 
 import           Control.Monad              (mzero)
@@ -21,6 +23,8 @@ import           Data.Text                  (Text)
 import qualified Data.Text                  as T
 import           Data.Time.Clock            (UTCTime)
 import           GHC.Generics
+import           Network.HTTP.Client
+import qualified Network.HTTP.Types.Method  as NHTM
 
 -- | Username type used for HTTP Basic authentication.
 newtype Username = Username
@@ -540,3 +544,6 @@ instance FromJSON PieceContent where
         defaultOptions
         { fieldLabelModifier = downcaseHead . drop 12
         }
+
+type Reply = Network.HTTP.Client.Response BSL.ByteString
+type Method = NHTM.Method

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -16,6 +16,7 @@ import           Data.ByteString            (ByteString)
 import qualified Data.ByteString            as BS
 import qualified Data.ByteString.Lazy.Char8 as BSL
 import qualified Data.Char                  as DC
+import           Data.Fixed
 import           Data.Text                  (Text)
 import qualified Data.Text                  as T
 import           Data.Time.Clock            (UTCTime)
@@ -378,9 +379,9 @@ data Cost =
     costCurrency         :: Text
   , costType             :: Text
   , costName             :: Text
-  , costAmount           :: Float
+  , costAmount           :: Centi
   , costConverted        :: Bool
-  , costOriginalCost     :: Float
+  , costOriginalCost     :: Centi
   , costOriginalCurrency :: Text
   } deriving (Eq, Generic, Show)
 
@@ -396,9 +397,9 @@ data Subtotal =
     subtotalCurrency         :: Text
   , sbutotalType             :: Text
   , subtotalName             :: Text
-  , subtotalAmount           :: Float
+  , subtotalAmount           :: Centi
   , subtotalConverted        :: Bool
-  , subtotalOriginalCost     :: Float
+  , subtotalOriginalCost     :: Centi
   , subtotalOriginalCurrency :: Text
   } deriving (Eq, Generic, Show)
 
@@ -441,7 +442,7 @@ type PieceHeight = PieceLength
 
 data PieceWeight =
   PieceWeight {
-    pwAmount :: Float
+    pwAmount :: Double
   , pwUnits  :: Text
   , pwType   :: Text
   } deriving (Eq, Generic, Show)

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -386,10 +386,31 @@ instance FromJSON ServiceOptions where
         }
 
 data ServiceOption = ServiceOption
-  { sOptServiceLevelCode :: Text
+  { sOptServiceLevelCode :: ServiceLevelCode
   , sOptServiceLevelName :: Text
   , sOptShipments        :: [Shipment]
   } deriving (Eq, Generic, Show)
+
+data ServiceLevelCode
+  = DomesticGround
+  | DomesticTwoDay
+  | DomesticOneDay
+  | InternationalEconomy
+  | InternationalStandard
+  | InternationalPlus
+  | InternationalPremium
+  deriving (Eq, Generic, Show)
+
+instance FromJSON ServiceLevelCode where
+  parseJSON = withText "serviceLevelCode" parse
+    where
+      parse "GD"      = pure DomesticGround
+      parse "2D"      = pure DomesticTwoDay
+      parse "1D"      = pure DomesticOneDay
+      parse "E-INTL"  = pure InternationalEconomy
+      parse "INTL"    = pure InternationalStandard
+      parse "PL-INTL" = pure InternationalPlus
+      parse "PM-INTL" = pure InternationalPremium
 
 instance FromJSON ServiceOption where
   parseJSON sopt = genericParseJSON options sopt

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -129,38 +129,58 @@ defaultShipTo =
 
 newtype AddressLine =
   AddressLine { unAddressLine :: Text }
-  deriving (Eq, Show)
+  deriving (Eq, Generic, Show)
 
 instance ToJSON AddressLine where
-  toJSON (AddressLine a) = toJSON a
+  toJSON address =
+    genericToJSON options address
+    where
+      options =
+        defaultOptions { unwrapUnaryRecords = True }
 
 newtype City =
   City { unCity :: Text }
-  deriving (Eq, Show)
+  deriving (Eq, Generic, Show)
 
 instance ToJSON City where
-  toJSON (City c) = toJSON c
+  toJSON city =
+    genericToJSON options city
+    where
+      options =
+        defaultOptions { unwrapUnaryRecords = True }
 
 newtype PostalCode =
   PostalCode { unPostalCode :: Text }
-  deriving (Eq, Show)
+  deriving (Eq, Generic, Show)
 
 instance ToJSON PostalCode where
-  toJSON (PostalCode p) = toJSON p
+  toJSON code =
+    genericToJSON options code
+    where
+      options =
+        defaultOptions { unwrapUnaryRecords = True }
 
 newtype Region =
   Region { unRegion :: Text }
-  deriving (Eq, Show)
+  deriving (Eq, Generic, Show)
 
 instance ToJSON Region where
-  toJSON (Region r) = toJSON r
+  toJSON region =
+    genericToJSON options region
+    where
+      options =
+        defaultOptions { unwrapUnaryRecords = True }
 
 newtype Country =
   Country { unCountry :: Text }
-  deriving (Eq, Show)
+  deriving (Eq, Generic, Show)
 
 instance ToJSON Country where
-  toJSON (Country c) = toJSON c
+  toJSON country =
+    genericToJSON options country
+    where
+      options =
+        defaultOptions { unwrapUnaryRecords = True }
 
 downcaseHead :: [Char] -> [Char]
 downcaseHead [] = []

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE TypeFamilies      #-}
 
 module Ballast.Types
   ( Username(..)
@@ -26,6 +27,9 @@ module Ballast.Types
   , Rates(..)
   , ServiceOptions(..)
   , Resource(..)
+  , ShipWireRequest(..)
+  , mkShipWireRequest
+  , ShipWireReturn(..)
   , defaultRate
   , Reply
   , Method
@@ -588,3 +592,17 @@ instance FromJSON PieceContent where
 
 type Reply = Network.HTTP.Client.Response BSL.ByteString
 type Method = NHTM.Method
+
+data ShipWireRequest a = ShipWireRequest
+  { rMethod  :: Method
+  , endpoint :: Text
+  , body     :: Maybe BSL.ByteString
+  }
+
+mkShipWireRequest :: Method -> Text -> Maybe BSL.ByteString -> ShipWireRequest a
+mkShipWireRequest m e b = ShipWireRequest m e b
+
+type family ShipWireReturn a :: *
+
+-- data CreateRateResponse
+type instance ShipWireReturn RateResponse = RateResponse

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -57,7 +57,5 @@ main :: IO ()
 main = hspec $ do
   describe "get rates" $ do
     it "gets the correct rates" $ do
-      req <- mkRequest NHTM.methodPost (T.pack "/rate") (Just $ encode exampleRate)
-      let decodedReq = eitherDecode $ responseBody req :: Either String (Maybe RateResponse)
-
-      liftIO $ decodedReq `shouldBe` Right (Just exampleRateResponse)
+      request <- dispatch (createRateResponse (Just $ encode defaultRate))
+      liftIO $ request `shouldBe` (Right exampleRateResponse)

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -12,8 +12,8 @@ import qualified Network.HTTP.Types.Method as NHTM
 
 import           Test.Hspec
 
-exampleRate :: Rate
-exampleRate = Rate exampleRateOptions exampleRateOrder
+exampleGetRate :: GetRate
+exampleGetRate = GetRate exampleRateOptions exampleRateOrder
 
 exampleRateOptions :: RateOptions
 exampleRateOptions = RateOptions USD GroupByAll 1 WarehouseAreaUS Nothing
@@ -38,11 +38,12 @@ exampleShipTo =
     NotPoBox
 
 exampleRateResponse :: RateResponse
-exampleRateResponse = RateResponse { rateResponseStatus = 200
-                                   , rateResponseMessage = "Successful"
-                                   , rateResponseWarnings = Nothing
+exampleRateResponse = RateResponse { rateResponseStatus           = 200
+                                   , rateResponseMessage          = "Successful"
+                                   , rateResponseWarnings         = Nothing
+                                   , rateResponseErrors           = Nothing
                                    , rateResponseResourceLocation = Nothing
-                                   , rateResponseResource = exampleResource
+                                   , rateResponseResource         = Just exampleResource
                                    }
 
 exampleResource :: Resource
@@ -57,5 +58,5 @@ main :: IO ()
 main = hspec $ do
   describe "get rates" $ do
     it "gets the correct rates" $ do
-      request <- dispatch (createRateResponse (Just $ encode defaultRate))
+      request <- dispatch $ createRateRequest defaultGetRate
       liftIO $ request `shouldBe` (Right exampleRateResponse)

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import           Ballast.Client
+import           Ballast.Types
+import           Control.Monad.IO.Class
+import           Data.Aeson
+import qualified Data.Text                 as T
+import           Network.HTTP.Client
+import qualified Network.HTTP.Types.Method as NHTM
+
+import           Test.Hspec
+
+exampleRate :: Rate
+exampleRate = Rate exampleRateOptions exampleRateOrder
+
+exampleRateOptions :: RateOptions
+exampleRateOptions = RateOptions USD GroupByAll 1 WarehouseAreaUS Nothing
+
+exampleRateOrder :: RateOrder
+exampleRateOrder = RateOrder exampleShipTo exampleItems
+
+exampleItems :: Items
+exampleItems = [ItemInfo ((SKU "Ballasttest"), 1)]
+
+exampleShipTo :: ShipTo
+exampleShipTo =
+  ShipTo
+    (AddressLine "6501 Railroad Avenue SE")
+    (AddressLine "Room 315")
+    (AddressLine "")
+    (City "Snoqualmie")
+    (PostalCode "85283")
+    (Region "WA")
+    (Country "US")
+    Commercial
+    NotPoBox
+
+exampleRateResponse :: RateResponse
+exampleRateResponse = RateResponse { rateResponseStatus = 200
+                                   , rateResponseMessage = "Successful"
+                                   , rateResponseWarnings = Nothing
+                                   , rateResponseResourceLocation = Nothing
+                                   , rateResponseResource = exampleResource
+                                   }
+
+exampleResource :: Resource
+exampleResource = Resource { resourceGroupBy = GroupByAll
+                           , resourceRates = exampleRates
+                           }
+
+exampleRates :: Rates
+exampleRates = Rates { rateServiceOptions = [ServiceOptions [] Nothing Nothing] }
+
+main :: IO ()
+main = hspec $ do
+  describe "get rates" $ do
+    it "gets the correct rates" $ do
+      req <- mkRequest NHTM.methodPost (T.pack "/rate") (Just $ encode exampleRate)
+      let decodedReq = eitherDecode $ responseBody req :: Either String (Maybe RateResponse)
+
+      liftIO $ decodedReq `shouldBe` Right (Just exampleRateResponse)


### PR DESCRIPTION
Hi there!

Making this pull request early because I have a bunch of questions about how to do certain things.

I've been looking at  bazaari and how the types are implemented there and was wondering if I should add the "un-" accessors to the dataypes, like here:

`newtype PostalCode =
  PostalCode { unPostalCode :: T.Text }
  deriving (Eq, Show)
`

Beyond that I am also not sure if I should add similar functions to `PostalCode`, `AddressLine` and so on:

`makeAddressLine :: T.Text -> Either T.Text AddressLine`
`makeAddressLine line`
`| T.length line == 0   = Left "Empty line"`
`| T.length line >  180 = Left "line is too long"`
`| T.length line <= 180 = Right $ AddressLine line`

I couldn't find any specific information on what the limits are for those fields for Shipwire. Are those supposed to be arbitrary, "common sense" values or is it actually stated somewhere?

As you can see in the `defaultShipTo` I use `T.pack` everywhere to convert Strings to Text. 

```
defaultShipTo =
  ShipTo (AddressLine (T.pack "15 Bergen ave")) (AddressLine (T.pack ""))
         (AddressLine (T.pack "")) (City (T.pack "Jersey City"))
         (PostalCode (T.pack "123456")) (Region (T.pack "US")) (Country (T.pack "US"))
         False False
```

Is that normal? Feels dirty.

Another thing that confuses me a bit is the API restrictions on what is required and what isn't.
For example, if we look at the model schema of the Request class, we'll see this:
`
  "required": [
                        "country"
                    ],
`
Does this mean that all the other things inside `shipTo` are actually not required?
A bit below that I also found another required clause:
`
            "required": [
                "shipTo",
                "items"
            ],
`
It's nested one level above the country one. If `shipTo` is required here, does that mean all the nested fields in `shipTo` are required as well? Doesn't seem to be that way, otherwise what's the point of specifying the `country` separately? I might be wrong, of course.

Thank you!

**UPD:** Ignore the question about the accessors, just realized that the `SKU` datatype you've made had one. I'll add them to all the other ones in a later commit. My bad.

**UPD2:** TIR (Today I Remembered) that `OverLoadedStrings` allows you to write `Text` without the need of `T.pack` everywhere. That covers another question.

P.S. One of my vim plugins aligns the imports and things like that which adds additional changes in git. If that's too annoying, I will turn it off.
