### PR TITLE
Add /products endpoint

### DIFF
--- a/ballast.cabal
+++ b/ballast.cabal
@@ -31,6 +31,7 @@ library
                      , hspec-expectations
                      , vector
                      , unordered-containers
+                     , either-unwrap
   default-language:    Haskell2010
   ghc-options: -Wall
 
@@ -45,7 +46,8 @@ test-suite tests
                        hspec                >= 1.8 && <2.3,
                        hspec-expectations,
                        text,
-                       time
+                       time,
+                       either-unwrap
                        
   default-language:    Haskell2010
 

--- a/ballast.cabal
+++ b/ballast.cabal
@@ -44,7 +44,8 @@ test-suite tests
                        bytestring,
                        hspec                >= 1.8 && <2.3,
                        hspec-expectations,
-                       text
+                       text,
+                       time
                        
   default-language:    Haskell2010
 

--- a/ballast.cabal
+++ b/ballast.cabal
@@ -30,6 +30,7 @@ library
                      , hspec
                      , hspec-expectations
                      , vector
+                     , unordered-containers
   default-language:    Haskell2010
   ghc-options: -Wall
 

--- a/src/Ballast/Client.hs
+++ b/src/Ballast/Client.hs
@@ -156,6 +156,15 @@ getProducts = request
     url = "/products"
     params = []
 
+-- | Create new products of any classification.
+-- https://www.shipwire.com/w/developers/product/#panel-shipwire1
+createProduct :: [CreateProductsWrapper] -> ShipwireRequest CreateProductsRequest TupleBS8 BSL.ByteString
+createProduct cpr = request
+  where
+    request = mkShipwireRequest NHTM.methodPost url params
+    url = "/products"
+    params = [Body (encode cpr)]
+
 -- "{\"status\":401,\"message\":\"Please include a valid Authorization header (Basic)\",\"resourceLocation\":null}"
 
 shipwire' :: (FromJSON (ShipwireReturn a))

--- a/src/Ballast/Client.hs
+++ b/src/Ballast/Client.hs
@@ -147,6 +147,15 @@ getReceivingLabels receivingId = request
     url = T.concat ["/receivings/", getReceivingId receivingId, "/labels"]
     params = []
 
+-- | Get an itemized list of products.
+-- https://www.shipwire.com/w/developers/product/#panel-shipwire0
+getProducts :: ShipwireRequest GetProductsRequest TupleBS8 BSL.ByteString
+getProducts = request
+  where
+    request = mkShipwireRequest NHTM.methodGet url params
+    url = "/products"
+    params = []
+
 -- "{\"status\":401,\"message\":\"Please include a valid Authorization header (Basic)\",\"resourceLocation\":null}"
 
 shipwire' :: (FromJSON (ShipwireReturn a))

--- a/src/Ballast/Client.hs
+++ b/src/Ballast/Client.hs
@@ -165,22 +165,22 @@ createProduct cpr = request
     url = "/products"
     params = [Body (encode cpr)]
 
--- | Indicates that the listed products will not longer be used.
--- https://www.shipwire.com/w/developers/product/#panel-shipwire5
-retireProducts :: ProductsToRetire -> ShipwireRequest RetireProductsRequest TupleBS8 BSL.ByteString
-retireProducts ptr = request
-  where
-    request = mkShipwireRequest NHTM.methodPost url params
-    url = "/products/retire"
-    params = [Body (encode ptr)]
-
 -- | Modify products of any classification.
 -- https://www.shipwire.com/w/developers/product/#panel-shipwire2
-modifyProduct :: [CreateProductsWrapper] -> ShipwireRequest ModifyProductsRequest TupleBS8 BSL.ByteString
-modifyProduct mpr = request
+modifyProducts :: [CreateProductsWrapper] -> ShipwireRequest ModifyProductsRequest TupleBS8 BSL.ByteString
+modifyProducts mpr = request
   where
     request = mkShipwireRequest NHTM.methodPut url params
     url = "/products"
+    params = [Body (encode mpr)]
+
+-- | Modify a product.
+-- https://www.shipwire.com/w/developers/product/#panel-shipwire3
+modifyProduct :: CreateProductsWrapper -> Id -> ShipwireRequest ModifyProductRequest TupleBS8 BSL.ByteString
+modifyProduct mpr productId= request
+  where
+    request = mkShipwireRequest NHTM.methodPut url params
+    url = T.append "/products/" $ T.pack . show $ unId productId
     params = [Body (encode mpr)]
 
 -- | Get information about a product.
@@ -191,6 +191,16 @@ getProduct productId = request
     request = mkShipwireRequest NHTM.methodGet url params
     url = T.append "/products/" $ T.pack . show $ unId productId
     params = []
+
+-- | Indicates that the listed products will not longer be used.
+-- https://www.shipwire.com/w/developers/product/#panel-shipwire5
+retireProducts :: ProductsToRetire -> ShipwireRequest RetireProductsRequest TupleBS8 BSL.ByteString
+retireProducts ptr = request
+  where
+    request = mkShipwireRequest NHTM.methodPost url params
+    url = "/products/retire"
+    params = [Body (encode ptr)]
+
 
 -- "{\"status\":401,\"message\":\"Please include a valid Authorization header (Basic)\",\"resourceLocation\":null}"
 

--- a/src/Ballast/Client.hs
+++ b/src/Ballast/Client.hs
@@ -165,6 +165,15 @@ createProduct cpr = request
     url = "/products"
     params = [Body (encode cpr)]
 
+-- | Indicates that the listed products will not longer be used.
+-- https://www.shipwire.com/w/developers/product/#panel-shipwire5
+retireProducts :: ProductsToRetire -> ShipwireRequest RetireProductsRequest TupleBS8 BSL.ByteString
+retireProducts ptr = request
+  where
+    request = mkShipwireRequest NHTM.methodPost url params
+    url = "/products/retire"
+    params = [Body (encode ptr)]
+
 -- "{\"status\":401,\"message\":\"Please include a valid Authorization header (Basic)\",\"resourceLocation\":null}"
 
 shipwire' :: (FromJSON (ShipwireReturn a))

--- a/src/Ballast/Client.hs
+++ b/src/Ballast/Client.hs
@@ -183,6 +183,15 @@ modifyProduct mpr = request
     url = "/products"
     params = [Body (encode mpr)]
 
+-- | Get information about a product.
+-- https://www.shipwire.com/w/developers/product/#panel-shipwire4
+getProduct :: Id -> ShipwireRequest GetProductRequest TupleBS8 BSL.ByteString
+getProduct productId = request
+  where
+    request = mkShipwireRequest NHTM.methodGet url params
+    url = T.append "/products/" $ T.pack . show $ unId productId
+    params = []
+
 -- "{\"status\":401,\"message\":\"Please include a valid Authorization header (Basic)\",\"resourceLocation\":null}"
 
 shipwire' :: (FromJSON (ShipwireReturn a))

--- a/src/Ballast/Client.hs
+++ b/src/Ballast/Client.hs
@@ -174,6 +174,15 @@ retireProducts ptr = request
     url = "/products/retire"
     params = [Body (encode ptr)]
 
+-- | Modify products of any classification.
+-- https://www.shipwire.com/w/developers/product/#panel-shipwire2
+modifyProduct :: [CreateProductsWrapper] -> ShipwireRequest ModifyProductsRequest TupleBS8 BSL.ByteString
+modifyProduct mpr = request
+  where
+    request = mkShipwireRequest NHTM.methodPut url params
+    url = "/products"
+    params = [Body (encode mpr)]
+
 -- "{\"status\":401,\"message\":\"Please include a valid Authorization header (Basic)\",\"resourceLocation\":null}"
 
 shipwire' :: (FromJSON (ShipwireReturn a))

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -517,7 +517,8 @@ import           Data.Monoid ((<>))
 import           Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
-import           Data.Time.Clock (UTCTime)
+import           Data.Time.Clock
+import           Data.Time.LocalTime
 import qualified Data.Vector as V
 import           Network.HTTP.Client
 import qualified Network.HTTP.Types.Method as NHTM
@@ -4341,6 +4342,24 @@ instance FromJSON InclusionRulesResource where
                 <*> o .:  "insertWhenWorthValueCurrency"
                 <*> o .:  "insertWhenQuantity"
                 <*> o .:? "flags"
+
+utcToDumbShipwire :: UTCTime -> Text
+utcToDumbShipwire t =
+  (tshow day) <> "T" <> clockTime <> "-00:00"
+  where tshow :: Show a => a -> Text
+        tshow = T.pack . show
+        day = utctDay t
+        time = utctDayTime t
+        tod = snd $ utcToLocalTimeOfDay utc (timeToTimeOfDay time)
+        atLeastTwo :: Text -> Int -> Text
+        atLeastTwo t i
+          | i < 10 = t <> (tshow i)
+          | otherwise = tshow i
+        clockTime = (atLeastTwo "0" $ todHour tod)
+                 <> ":"
+                 <> (atLeastTwo "0" $ todMin tod)
+                 <> ":"
+                 <> (atLeastTwo "0" $ floor $ todSec tod)
 
 -- | ISO 8601 format, ex: "2014-05-30T13:08:29-07:00"
 newtype InsertAfterDate = InsertAfterDate

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -130,7 +130,7 @@ module Ballast.Types
   , ResponseNext(..)
   , StockItem(..)
   , StockItemResource(..)
-  , ProductId
+  , ProductId(..)
   , ProductExternalId
   , WarehouseRegion(..)
   , StockItemResourcePending(..)
@@ -413,12 +413,12 @@ module Ballast.Types
   , VirtualKitContentResourceItemResource(..)
   , VirtualKitFlags(..)
   , KitResponseResource(..)
-  , KitMasterCase
-  , KitTechnicalData(..)
-  , KitTechnicalDataResource(..)
-  , KitTechnicalDataResourceBattery(..)
+  , KitResponseMasterCase
+  , KitResponseTechnicalData(..)
+  , KitResponseTechnicalDataResource(..)
+  , KitResponseTechnicalDataResourceBattery(..)
   , KitTechnicalDataResourceBatteryResource
-  , KitContent
+  , KitResponseContent
   , ExpandProductsParam(..)
   , ExpandProducts(..)
   , expandProductsToTx
@@ -449,7 +449,7 @@ module Ballast.Types
   , BaseProductMasterCaseFlags(..)
   , BaseProductInnerPackFlags(..)
   , BaseProductTechnicalData(..)
-  , BaseProductTechnicalDataResource(..)
+  , BaseProductTechnicalDataBattery(..)
   , BaseProductDimensions(..)
   , BaseProductLength(..)
   , BaseProductWidth(..)
@@ -482,7 +482,27 @@ module Ballast.Types
   , MarketingInsertMasterCaseDimensionsWeight(..)
   , ProductError(..)
   -- , VirtualKit(..)
-  -- , Kit(..)
+  , Kit(..)
+  , KitPallet(..)
+  , KitPalletFlags(..)
+  , KitMasterCase(..)
+  , KitMasterCaseFlags(..)
+  , KitInnerPack(..)
+  , KitInnerPackFlags(..)
+  , KitFlags(..)
+  , HasBattery(..)
+  , KitTechnicalData(..)
+  , KitTechnicalDataBattery(..)
+  , KitDimensions(..)
+  , KitLength(..)
+  , KitWidth(..)
+  , KitHeight(..)
+  , KitWeight(..)
+  , KitContent(..)
+  , KitContentObject(..)
+  , KitAlternateNames(..)
+  , KitAlternateName(..)
+  , KitValues(..)
   ) where
 
 import           Data.Aeson
@@ -1489,7 +1509,11 @@ instance FromJSON StockItemResource where
                 <*> o .:  "orderedLastWeek"
                 <*> o .:  "orderedLast4Weeks"
 
-type ProductId = Id
+-- type ProductId = Id
+
+newtype ProductId = ProductId
+  { unProductId :: Integer
+  } deriving (Eq, Show, ToJSON, FromJSON)
 
 type ProductExternalId = ExternalId
 
@@ -3150,14 +3174,242 @@ type CreateProductsResponse = GetProductsResponse
 data CreateProductsWrapper = CpwBaseProduct BaseProduct
   | CpwMarketingInsert MarketingInsert
   -- | CpwVirtualKit VirtualKit
-  -- | CpwKit Kit
+  | CpwKit Kit
   deriving (Eq, Show)
 
 instance ToJSON CreateProductsWrapper where
   toJSON (CpwBaseProduct x)     = toJSON x
   toJSON (CpwMarketingInsert x) = toJSON x
   -- toJSON (CpwVirtualKit x)      = toJSON x
-  -- toJSON (CpwKit x)             = toJSON x
+  toJSON (CpwKit x)             = toJSON x
+  
+data Kit = Kit
+  { kSku                  :: SKU
+  , kExternalId           :: Maybe ExternalId
+  , kClassification       :: Classification
+  , kDescription          :: Description
+  , kBatteryConfiguration :: BatteryConfiguration
+  , kHsCode               :: HsCode
+  , kCountryOfOrigin      :: CountryOfOrigin
+  , kValues               :: KitValues
+  , kAlternateNames       :: KitAlternateNames
+  , kContent              :: KitContent
+  , kDimensions           :: KitDimensions
+  , kTechnicalData        :: KitTechnicalData
+  , kFlags                :: KitFlags
+  , kInnerPack            :: KitInnerPack
+  , kMasterCase           :: KitMasterCase
+  , kPallet               :: KitPallet
+  } deriving (Eq, Show)
+
+instance ToJSON Kit where
+  toJSON Kit {..} = omitNulls ["sku"                  .= kSku
+                              ,"externalId"           .= kExternalId
+                              ,"classification"       .= kClassification
+                              ,"description"          .= kDescription
+                              ,"batteryConfiguration" .= kBatteryConfiguration
+                              ,"hsCode"               .= kHsCode
+                              ,"countryOfOrigin"      .= kCountryOfOrigin
+                              ,"values"               .= kValues
+                              ,"alternateNames"       .= kAlternateNames
+                              ,"kitContent"           .= kContent
+                              ,"dimensions"           .= kDimensions
+                              ,"technicalData"        .= kTechnicalData
+                              ,"flags"                .= kFlags
+                              ,"innerPack"            .= kInnerPack
+                              ,"masterCase"           .= kMasterCase
+                              ,"pallet"               .= kPallet]
+
+data KitPallet = KitPallet
+  { kpIndividualItemsPerCase :: IndividualItemsPerCase
+  , kpSku                    :: SKU
+  , kpDescription            :: Description
+  , kpValues                 :: KitValues
+  , kpDimensions             :: KitDimensions
+  , kpFlags                  :: KitPalletFlags
+  } deriving (Eq, Show)
+
+instance ToJSON KitPallet where
+  toJSON KitPallet {..} = object ["individualItemsPerCase" .= kpIndividualItemsPerCase
+                                 ,"sku"                    .= kpSku
+                                 ,"description"            .= kpDescription
+                                 ,"values"                 .= kpValues
+                                 ,"dimensions"             .= kpDimensions
+                                 ,"flags"                  .= kpFlags]
+
+newtype KitPalletFlags = KitPalletFlags
+  { kpfIsPackagedReadyToShip :: IsPackagedReadyToShip
+  } deriving (Eq, Show, ToJSON)
+
+data KitMasterCase = KitMasterCase
+  { kmcIndividualItemsPerCase :: IndividualItemsPerCase
+  , kmcSku                    :: SKU
+  , kmcDescription            :: Description
+  , kmcValues                 :: KitValues
+  , kmcDimensions             :: KitDimensions
+  , kmcFlags                  :: KitMasterCaseFlags
+  } deriving (Eq, Show)
+
+instance ToJSON KitMasterCase where
+  toJSON KitMasterCase {..} = object ["individualItemsPerCase" .= kmcIndividualItemsPerCase
+                                     ,"sku"                    .= kmcSku
+                                     ,"description"            .= kmcDescription
+                                     ,"values"                 .= kmcValues
+                                     ,"dimensions"             .= kmcDimensions
+                                     ,"flags"                  .= kmcFlags]
+
+newtype KitMasterCaseFlags = KitMasterCaseFlags
+  { kmcfIsPackagedReadyToShip :: IsPackagedReadyToShip
+  } deriving (Eq, Show, ToJSON)
+
+data KitInnerPack = KitInnerPack
+  { kipIndividualItemsPerCase :: IndividualItemsPerCase
+  , kipSku                    :: SKU
+  , kipDescription            :: Description
+  , kipValues                 :: KitValues
+  , kipDimensions             :: KitDimensions
+  , kipFlags                  :: KitInnerPackFlags
+  } deriving (Eq, Show)
+
+instance ToJSON KitInnerPack where
+  toJSON KitInnerPack {..} = object ["individualItemsPerCase" .= kipIndividualItemsPerCase
+                                    ,"sku"                    .= kipSku
+                                    ,"description"            .= kipDescription
+                                    ,"values"                 .= kipValues
+                                    ,"dimensions"             .= kipDimensions
+                                    ,"flags"                  .= kipFlags]
+
+newtype KitInnerPackFlags = KitInnerPackFlags
+  { kipfIsPackagedReadyToShip :: IsPackagedReadyToShip
+  } deriving (Eq, Show, ToJSON)
+
+data KitFlags = KitFlags
+  { kfIsPackagedReadyToShip :: IsPackagedReadyToShip
+  , kfIsFragile             :: IsFragile
+  , kfIsDangerous           :: IsDangerous
+  , kfIsPerishable          :: IsPerishable
+  , kfIsMedia               :: IsMedia
+  , kfIsAdult               :: IsAdult
+  , kfIsLiquid              :: IsLiquid
+  , kfHasBattery            :: HasBattery
+  , kfHasInnerPack          :: HasInnerPack
+  , kfHasMasterCase         :: HasMasterCase
+  , kfHasPallet             :: HasPallet
+  } deriving (Eq, Show)
+
+instance ToJSON KitFlags where
+  toJSON KitFlags {..} = object ["isPackagedReadyToShip" .= kfIsPackagedReadyToShip
+                                ,"isFragile"             .= kfIsFragile
+                                ,"isDangerous"           .= kfIsDangerous
+                                ,"isPerishable"          .= kfIsPerishable
+                                ,"isMedia"               .= kfIsMedia
+                                ,"isAdult"               .= kfIsAdult
+                                ,"isLiquid"              .= kfIsLiquid
+                                ,"hasBattery"            .= kfHasBattery
+                                ,"hasInnerPack"          .= kfHasInnerPack
+                                ,"hasMasterCase"         .= kfHasMasterCase
+                                ,"hasPallet"             .= kfHasPallet]
+
+data HasBattery = HasBattery
+  | NoBattery
+  deriving (Eq, Show)
+
+instance ToJSON HasBattery where
+  toJSON HasBattery = Number 1
+  toJSON NoBattery  = Number 0
+
+newtype KitTechnicalData = KitTechnicalData
+  { ktdTechnicalDataBattery :: KitTechnicalDataBattery
+  } deriving (Eq, Show, ToJSON)
+
+data KitTechnicalDataBattery = KitTechnicalDataBattery
+  { ktdbType              :: BatteryType
+  , ktdbBatteryWeight     :: BatteryWeight
+  , ktdbNumberOfBatteries :: NumberOfBatteries
+  , ktdbCapacity          :: Capacity
+  , ktdbNumberOfCells     :: NumberOfCells
+  , ktdbCapacityUnit      :: CapacityUnit
+  } deriving (Eq, Show)
+
+instance ToJSON KitTechnicalDataBattery where
+  toJSON KitTechnicalDataBattery {..} = object ["type"              .= ktdbType
+                                               ,"batteryWeight"     .= ktdbBatteryWeight
+                                               ,"numberOfBatteries" .= ktdbNumberOfBatteries
+                                               ,"capacity"          .= ktdbCapacity
+                                               ,"numberOfCells"     .= ktdbNumberOfCells
+                                               ,"capacityUnit"      .= ktdbCapacityUnit]
+
+data KitDimensions = KitDimensions
+  { kdLength :: KitLength
+  , kdWidth  :: KitWidth
+  , kdHeight :: KitHeight
+  , kdWeight :: KitWeight
+  } deriving (Eq, Show)
+
+instance ToJSON KitDimensions where
+  toJSON KitDimensions {..} = object ["length" .= kdLength
+                                     ,"width"  .= kdWidth
+                                     ,"height" .= kdHeight
+                                     ,"weight" .= kdWeight]
+
+newtype KitLength = KitLength
+  { unKitLength :: Integer
+  } deriving (Eq, Show, ToJSON)
+
+newtype KitWidth = KitWidth
+  { unKitWidth :: Integer
+  } deriving (Eq, Show, ToJSON)
+
+newtype KitHeight = KitHeight
+  { unKitHeight :: Integer
+  } deriving (Eq, Show, ToJSON)
+
+newtype KitWeight = KitWeight
+  { unKitWeight :: Integer
+  } deriving (Eq, Show, ToJSON)
+
+newtype KitContent = KitContent
+  { unKitContent :: [KitContentObject]
+  } deriving (Eq, Show, ToJSON)
+
+data KitContentObject = KitContentObject
+  { kcProductId  :: ProductId
+  , kcExternalId :: Maybe ExternalId
+  , kcQuantity   :: Quantity
+  } deriving (Eq, Show)
+
+instance ToJSON KitContentObject where
+  toJSON KitContentObject {..} = omitNulls ["productId"  .= kcProductId
+                                           ,"externalId" .= kcExternalId
+                                           ,"quantity"   .= kcQuantity]
+
+newtype KitAlternateNames = KitAlternateNames
+  { kanAlternateNames :: [KitAlternateName]
+  } deriving (Eq, Show, ToJSON)
+
+newtype KitAlternateName = KitAlternateName
+  { kanAlternateName :: Name
+  } deriving (Eq, Show)
+
+instance ToJSON KitAlternateName where
+  toJSON KitAlternateName {..} = object ["name" .= kanAlternateName]
+
+data KitValues = KitValues
+  { kvCostValue         :: CostValue
+  , kvWholesaleValue    :: WholesaleValue
+  , kvRetailValue       :: RetailValue
+  , kvCostCurrency      :: CostCurrency
+  , kvWholesaleCurrency :: WholesaleCurrency
+  , kvRetailCurrency    :: RetailCurrency
+  } deriving (Eq, Show)
+
+instance ToJSON KitValues where
+  toJSON KitValues {..} = object ["costValue"         .= kvCostValue
+                                 ,"wholesaleValue"    .= kvWholesaleValue
+                                 ,"retailValue"       .= kvRetailValue
+                                 ,"costCurrency"      .= kvCostCurrency
+                                 ,"wholesaleCurrency" .=  kvWholesaleCurrency
+                                 ,"retailCurrency"    .= kvRetailCurrency]
 
 data MarketingInsert = MarketingInsert
   { miSku               :: SKU
@@ -3480,25 +3732,25 @@ instance ToJSON BaseProductFlags where
                                         ,"hasPallet"             .= bpfHasPallet]
 
 newtype BaseProductTechnicalData = BaseProductTechnicalData
-  { unTechnicalDataResource :: BaseProductTechnicalDataResource
+  { bptdTechnicalDataBattery :: BaseProductTechnicalDataBattery
   } deriving (Eq, Show, ToJSON)
 
-data BaseProductTechnicalDataResource = BaseProductTechnicalDataResource
-  { bptdrType              :: BatteryType
-  , bptdrBatteryWeight     :: BatteryWeight
-  , bptdrNumberOfBatteries :: NumberOfBatteries
-  , bptdrCapacity          :: Capacity
-  , bptdrNumberOfCells     :: NumberOfCells
-  , bptdrCapacityUnit      :: CapacityUnit
+data BaseProductTechnicalDataBattery = BaseProductTechnicalDataBattery
+  { bptdbType              :: BatteryType
+  , bptdbBatteryWeight     :: BatteryWeight
+  , bptdbNumberOfBatteries :: NumberOfBatteries
+  , bptdbCapacity          :: Capacity
+  , bptdbNumberOfCells     :: NumberOfCells
+  , bptdbCapacityUnit      :: CapacityUnit
   } deriving (Eq, Show)
 
-instance ToJSON BaseProductTechnicalDataResource where
-  toJSON BaseProductTechnicalDataResource {..} = object ["type"              .= bptdrType
-                                                        ,"batteryWeight"     .= bptdrBatteryWeight
-                                                        ,"numberOfBatteries" .= bptdrNumberOfBatteries
-                                                        ,"capacity"          .= bptdrCapacity
-                                                        ,"numberOfCells"     .= bptdrNumberOfCells
-                                                        ,"capacityUnit"      .= bptdrCapacityUnit]
+instance ToJSON BaseProductTechnicalDataBattery where
+  toJSON BaseProductTechnicalDataBattery {..} = object ["type"              .= bptdbType
+                                                       ,"batteryWeight"     .= bptdbBatteryWeight
+                                                       ,"numberOfBatteries" .= bptdbNumberOfBatteries
+                                                       ,"capacity"          .= bptdbCapacity
+                                                       ,"numberOfCells"     .= bptdbNumberOfCells
+                                                       ,"capacityUnit"      .= bptdbCapacityUnit]
 
 data BaseProductDimensions = BaseProductDimensions
   { bpdLength :: BaseProductLength
@@ -3731,7 +3983,6 @@ instance FromJSON GetProductsResponseResourceItem where
       parse o = GetProductsResponseResourceItem
                 <$> o .: "resourceLocation"
                 <*> o .: "resource"
-
                 
 -- | This a wrapper for different classifications of products.
 -- Possible options are: baseProduct, marketingInsert, virtualKit, kit.
@@ -3777,12 +4028,12 @@ data KitResponseResource = KitResponseResource
   , krDimensions           :: Dimensions
   , krValues               :: ValuesResource
   , krAlternateNames       :: AlternateNamesResponse
-  , krKitContent           :: Maybe KitContent
-  , krTechnicalData        :: Maybe KitTechnicalData
+  , krKitContent           :: Maybe KitResponseContent
+  , krTechnicalData        :: Maybe KitResponseTechnicalData
   , krFlags                :: Flags
   , krEnqueuedDimensions   :: EnqueuedDimensions
   , krInnerPack            :: Maybe InnerPack
-  , krMasterCase           :: Maybe KitMasterCase
+  , krMasterCase           :: Maybe KitResponseMasterCase
   , krPallet               :: Maybe Pallet
   } deriving (Eq, Show)
 
@@ -3817,39 +4068,39 @@ parseKit o = KitResponseResource
              <*> o .:? "masterCase"
              <*> o .:? "pallet"
 
-type KitMasterCase = BaseProductResponseMasterCase
+type KitResponseMasterCase = BaseProductResponseMasterCase
 
-data KitTechnicalData = KitTechnicalData
+data KitResponseTechnicalData = KitResponseTechnicalData
   { ktdResourceLocation :: Maybe ResponseResourceLocation
-  , ktdResource         :: Maybe KitTechnicalDataResource
+  , ktdResource         :: Maybe KitResponseTechnicalDataResource
   } deriving (Eq, Show)
 
-instance FromJSON KitTechnicalData where
-  parseJSON = withObject "KitTechnicalData" parse
+instance FromJSON KitResponseTechnicalData where
+  parseJSON = withObject "KitResponseTechnicalData" parse
     where
-      parse o = KitTechnicalData
+      parse o = KitResponseTechnicalData
                 <$> o .:? "resourceLocation"
                 <*> o .:? "resource"
 
-newtype KitTechnicalDataResource = KitTechnicalDataResource
-  { ktdrBattery :: KitTechnicalDataResourceBattery
+newtype KitResponseTechnicalDataResource = KitResponseTechnicalDataResource
+  { ktdrBattery :: KitResponseTechnicalDataResourceBattery
   } deriving (Eq, Show, FromJSON)
 
-data KitTechnicalDataResourceBattery = KitTechnicalDataResourceBattery
+data KitResponseTechnicalDataResourceBattery = KitResponseTechnicalDataResourceBattery
   { ktdrbResourceLocation :: Maybe ResponseResourceLocation
   , ktdrbResource         :: KitTechnicalDataResourceBatteryResource
   } deriving (Eq, Show)
 
-instance FromJSON KitTechnicalDataResourceBattery where
-  parseJSON = withObject "KitTechnicalDataResourceBattery" parse
+instance FromJSON KitResponseTechnicalDataResourceBattery where
+  parseJSON = withObject "KitResponseTechnicalDataResourceBattery" parse
     where
-      parse o = KitTechnicalDataResourceBattery
+      parse o = KitResponseTechnicalDataResourceBattery
                 <$> o .:? "resourceLocation"
                 <*> o .:  "resource"
 
 type KitTechnicalDataResourceBatteryResource = TechnicalDataResource
 
-type KitContent = VirtualKitContent
+type KitResponseContent = VirtualKitContent
 
 data VirtualKitResponseResource = VirtualKitResponseResource
   { vkrId                :: Id
@@ -4061,14 +4312,10 @@ instance FromJSON InclusionRulesResource where
                 <*> o .:  "insertWhenQuantity"
                 <*> o .:? "flags"
 
--- type InsertAfterDate = ExpectedDateUTCTime
-
 -- | ISO 8601 format, ex: "2014-05-30T13:08:29-07:00"
 newtype InsertAfterDate = InsertAfterDate
   { unInsertAfterDate :: Text
   } deriving (Eq, Show, ToJSON, FromJSON)
-
--- type InsertBeforeDate = ExpectedDateUTCTime
 
 -- | ISO 8601 format, ex: "2014-05-30T13:08:29-07:00"
 newtype InsertBeforeDate = InsertBeforeDate
@@ -4080,8 +4327,6 @@ newtype InsertWhenWorthValueResponse = InsertWhenWorthValueResponse
   } deriving (Eq, Show, FromJSON)
 
 type InsertWhenWorthValueCurrency = CostCurrency
-
--- type InsertWhenQuantity = Quantity
 
 newtype InsertWhenQuantity = InsertWhenQuantity
   { unInsertWhenQuantity :: Integer

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -731,10 +731,10 @@ instance ToJSON Currency where
   toJSON USD = String "USD"
 
 instance FromJSON Currency where
-  parseJSON = withText "currency" parse
+  parseJSON = withText "Currency" parse
     where
       parse "USD" = pure USD
-      parse _     = error "Bad input"
+      parse o     = fail $ "Unexpected Currency: " <> show o
 
 omitNulls :: [(Text, Value)] -> Value
 omitNulls = object . filter notNull
@@ -753,11 +753,11 @@ instance ToJSON GroupBy where
   toJSON GroupByWarehouse = String "warehouse"
 
 instance FromJSON GroupBy where
-  parseJSON = withText "groupBy" parse
+  parseJSON = withText "GroupBy" parse
     where
       parse "all"       = pure GroupByAll
       parse "warehouse" = pure GroupByWarehouse
-      parse o           = fail ("Unexpected groupBy value: " <> show o)
+      parse o           = fail $ "Unexpected GroupBy: " <> show o
 
 data WarehouseArea =
   WarehouseAreaUS
@@ -842,11 +842,11 @@ data WarningType
   deriving (Eq, Show)
 
 instance FromJSON WarningType where
-  parseJSON = withText "warningType" parse
+  parseJSON = withText "WarningType" parse
     where
       parse "warning" = pure WarningWarning
       parse "error"   = pure WarningError
-      parse o         = fail ("Unexpected warningType value: " <> show o)
+      parse o         = fail $ "Unexpected WarningType: " <> show o
 
 data Error = Error
   { errorCode    :: ErrorCode
@@ -876,11 +876,11 @@ data ErrorType
   deriving (Eq, Show)
 
 instance FromJSON ErrorType where
-  parseJSON = withText "errorType" parse
+  parseJSON = withText "ErrorType" parse
     where
       parse "warning" = pure ErrorWarning
       parse "error"   = pure ErrorError
-      parse o         = fail ("Unexpected errorType value: " <> show o)
+      parse o         = fail $ "Unexpected ErrorType: " <> show o
 
 data RateResource = RateResource
   { resourceGroupBy :: GroupBy
@@ -952,7 +952,7 @@ data ServiceLevelCode
   deriving (Eq, Show)
 
 instance FromJSON ServiceLevelCode where
-  parseJSON = withText "serviceLevelCode" parse
+  parseJSON = withText "ServiceLevelCode" parse
     where
       parse "GD"      = pure DomesticGround
       parse "2D"      = pure DomesticTwoDay
@@ -961,7 +961,7 @@ instance FromJSON ServiceLevelCode where
       parse "INTL"    = pure InternationalStandard
       parse "PL-INTL" = pure InternationalPlus
       parse "PM-INTL" = pure InternationalPremium
-      parse o         = fail ("Unexpected serviceLevelCode value: " <> show o)
+      parse o         = fail $ "Unexpected ServiceLevelCode: " <> show o
 
 data Shipment = Shipment
   { shipmentWarehouseName           :: WarehouseName
@@ -1609,7 +1609,7 @@ data IsBundle
 instance FromJSON IsBundle where
   parseJSON (Number 1) = pure Bundle
   parseJSON (Number 0) = pure NotBundle
-  parseJSON o          = fail ("Unexpected isBundle value: " <> show o)
+  parseJSON o          = fail $ "Unexpected isBundle: " <> show o
 
 data IsAlias
   = Alias
@@ -1619,7 +1619,7 @@ data IsAlias
 instance FromJSON IsAlias where
   parseJSON (Number 1) = pure Alias
   parseJSON (Number 0) = pure NotAlias
-  parseJSON o          = fail ("Unexpected isAlias value: " <> show o)
+  parseJSON o          = fail $ "Unexpected isAlias: " <> show o
 
 -- | Either production or sandbox API host
 type Host = Text
@@ -2825,13 +2825,13 @@ data ArrangementType = ArrangementTypeNone
   deriving (Eq, Show)
 
 instance FromJSON ArrangementType where
-  parseJSON = withText "arrangementType" parse
+  parseJSON = withText "ArrangementType" parse
     where
       parse "none"     = pure ArrangementTypeNone
       parse "overseas" = pure ArrangementTypeOverseas
       parse "label"    = pure ArrangementTypeLabel
       parse "pickup"   = pure ArrangementTypePickup
-      parse o          = fail ("Unexpected arrangementType value: " <> show o)
+      parse o          = fail $ "Unexpected ArrangementType: " <> show o
 
 instance ToJSON ArrangementType where
   toJSON ArrangementTypeNone     = String "none"
@@ -4535,14 +4535,14 @@ data StorageConfiguration = IndividualItemConfiguration
   deriving (Eq, Show)
 
 instance FromJSON StorageConfiguration where
-  parseJSON = withText "storageConfiguration" parse
+  parseJSON = withText "StorageConfiguration" parse
     where
       parse "INDIVIDUAL_ITEM" = pure IndividualItemConfiguration
       parse "INNER_PACK"      = pure InnerPackConfiguration
       parse "MASTER_CASE"     = pure MasterCaseConfiguration
       parse "PALLET"          = pure PalletConfiguration
       parse "KIT"             = pure KitConfiguration
-      parse _                = error "Bad input"
+      parse o                 = fail $ "Unexpected StorageConfiguration: " <> show o
 
 newtype HsCode = HsCode
   { unHsCode :: Text
@@ -4601,11 +4601,11 @@ data IsAdult = Adult
   deriving (Eq, Show)
 
 instance FromJSON IsAdult where
-  parseJSON = withScientific "isAdult" parse
+  parseJSON = withScientific "IsAdult" parse
     where
       parse 0 = pure NotAdult
       parse 1 = pure Adult
-      parse _ = error "Bad value"
+      parse o = fail $ "Unexpected IsAdult: " <> show o
 
 instance ToJSON IsAdult where
   toJSON NotAdult = Number 0
@@ -4616,11 +4616,11 @@ data HasInnerPack = HasInnerPack
   deriving (Eq, Show)
 
 instance FromJSON HasInnerPack where
-  parseJSON = withScientific "hasInnerPack" parse
+  parseJSON = withScientific "HasInnerPack" parse
     where
       parse 0 = pure NoInnerPack
       parse 1 = pure HasInnerPack
-      parse _ = error "Bad value"
+      parse o = fail $ "Unexpected HasInnerPack: " <> show o
 
 instance ToJSON HasInnerPack where
   toJSON NoInnerPack  = Number 0
@@ -4631,22 +4631,22 @@ data HasEditRestrictions = EditRestrictions
   deriving (Eq, Show)
 
 instance FromJSON HasEditRestrictions where
-  parseJSON = withScientific "hasEditRestrictions" parse
+  parseJSON = withScientific "HasEditRestrictions" parse
     where
       parse 0 = pure NoEditRestrictions
       parse 1 = pure EditRestrictions
-      parse _ = error "Bad value"      
+      parse o = fail $ "Unexpected HasEditRestrictions: " <> show o
 
 data IsPerishable = Perishable
   | NotPerishable
   deriving (Eq, Show)
 
 instance FromJSON IsPerishable where
-  parseJSON = withScientific "isPerishable" parse
+  parseJSON = withScientific "IsPerishable" parse
     where
       parse 0 = pure NotPerishable
       parse 1 = pure Perishable
-      parse _ = error "Bad value"
+      parse o = fail $ "Unexpected IsPerishable: " <> show o
 
 instance ToJSON IsPerishable where
   toJSON NotPerishable = Number 0
@@ -4657,11 +4657,11 @@ data IsDangerous = Dangerous
   deriving (Eq, Show)
 
 instance FromJSON IsDangerous where
-  parseJSON = withScientific "isDangerous" parse
+  parseJSON = withScientific "IsDangerous" parse
     where
       parse 0 = pure NotDangerous
       parse 1 = pure Dangerous
-      parse _ = error "Bad value"
+      parse o = fail $ "Unexpected IsDangerous: " <> show o
 
 instance ToJSON IsDangerous where
   toJSON NotDangerous = Number 0
@@ -4672,11 +4672,11 @@ data IsLiquid = Liquid
   deriving (Eq, Show)
 
 instance FromJSON IsLiquid where
-  parseJSON = withScientific "isLiquid" parse
+  parseJSON = withScientific "IsLiquid" parse
     where
       parse 0 = pure NotLiquid
       parse 1 = pure Liquid
-      parse _ = error "Bad value"
+      parse o = fail $ "Unexpected IsLiquid: " <> show o
 
 instance ToJSON IsLiquid where
   toJSON NotLiquid = Number 0
@@ -4687,22 +4687,22 @@ data IsArchivable = Archivable
   deriving (Eq, Show)
 
 instance FromJSON IsArchivable where
-  parseJSON = withScientific "isArchivable" parse
+  parseJSON = withScientific "IsArchivable" parse
     where
       parse 0 = pure NotArchivable
       parse 1 = pure Archivable
-      parse _ = error "Bad value"      
+      parse o = fail $ "Unexpected IsArchivable: " <> show o
 
 data IsFragile = Fragile
   | NotFragile
   deriving (Eq, Show)
 
 instance FromJSON IsFragile where
-  parseJSON = withScientific "isFragile" parse
+  parseJSON = withScientific "IsFragile" parse
     where
       parse 0 = pure NotFragile
       parse 1 = pure Fragile
-      parse _ = error "Bad value"
+      parse o = fail $ "Unexpected IsFragile: " <> show o
 
 instance ToJSON IsFragile where
   toJSON NotFragile = Number 0
@@ -4713,11 +4713,11 @@ data HasMasterCase = HasMasterCase
   deriving (Eq, Show)
 
 instance FromJSON HasMasterCase where
-  parseJSON = withScientific "hasMasterCase" parse
+  parseJSON = withScientific "HasMasterCase" parse
     where
       parse 0 = pure NoMasterCase
       parse 1 = pure HasMasterCase
-      parse _ = error "Bad value"
+      parse o = fail $ "Unexpected HasMasterCase: " <> show o
 
 instance ToJSON HasMasterCase where
   toJSON NoMasterCase  = Number 0
@@ -4728,11 +4728,11 @@ data HasPallet = HasPallet
   deriving (Eq, Show)
 
 instance FromJSON HasPallet where
-  parseJSON = withScientific "hasPallet" parse
+  parseJSON = withScientific "HasPallet" parse
     where
       parse 0 = pure NoPallet
       parse 1 = pure HasPallet
-      parse _ = error "Bad value"
+      parse o = fail $ "Unexpected HasPallet: " <> show o
 
 instance ToJSON HasPallet where
   toJSON NoPallet  = Number 0
@@ -4743,22 +4743,22 @@ data IsDeletable = Deletable
   deriving (Eq, Show)
 
 instance FromJSON IsDeletable where
-  parseJSON = withScientific "isDeletable" parse
+  parseJSON = withScientific "IsDeletable" parse
     where
       parse 0 = pure NotDeletable
       parse 1 = pure Deletable
-      parse _ = error "Bad value"      
+      parse o = fail $ "Unexpected IsDeletable: " <> show o
 
 data IsMedia = Media
   | NotMedia
   deriving (Eq, Show)
 
 instance FromJSON IsMedia where
-  parseJSON = withScientific "isMedia" parse
+  parseJSON = withScientific "IsMedia" parse
     where
       parse 0 = pure NotMedia
       parse 1 = pure Media
-      parse _ = error "Bad value"
+      parse o = fail $ "Unexpected IsMedia: " <> show o
 
 instance ToJSON IsMedia where
   toJSON NotMedia = Number 0
@@ -4911,13 +4911,13 @@ instance ToJSON Classification where
   toJSON KitClassification             = String "kit"
 
 instance FromJSON Classification where
-  parseJSON = withText "classification" parse
+  parseJSON = withText "Classification" parse
     where
       parse "baseProduct"     = pure BaseProductClassification
       parse "marketingInsert" = pure MarketingInsertClassification
       parse "virtualKit"      = pure VirtualKitClassification
       parse "kit"             = pure KitClassification
-      parse _                 = error "Bad input"
+      parse o                 = fail $ "Unexpected Classification: " <> show o
 
 newtype BatteryConfiguration = BatteryConfiguration
   { unBatteryConfiguration :: Text
@@ -5137,11 +5137,11 @@ data IsPackagedReadyToShip = PackagedReadyToShip
   deriving (Eq, Show)
 
 instance FromJSON IsPackagedReadyToShip where
-  parseJSON = withScientific "isPackagedReadyToShip" parse
+  parseJSON = withScientific "IsPackagedReadyToShip" parse
     where
       parse 0 = pure NotPackagedReadyToShip
       parse 1 = pure PackagedReadyToShip
-      parse _ = error "Bad input"
+      parse o = fail $ "Unexpected IsPackagedReadyToShip: " <> show o
 
 instance ToJSON IsPackagedReadyToShip where
   toJSON NotPackagedReadyToShip = Number 0

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -4547,11 +4547,11 @@ instance FromJSON ValuesResponse where
 
 data ValuesResource = ValuesResource
   { vrCostValueCurrency      :: Maybe CostValueCurrency
-  , vrWholesaleValue         :: WholesaleValueResponse
-  , vrCostValue              :: CostValueResponse
-  , vrWholesaleValueCurrency :: WholesaleValueCurrency
-  , vrRetailValue            :: RetailValueResponse
-  , vrRetailValueCurrency    :: RetailValueCurrency
+  , vrWholesaleValue         :: Maybe WholesaleValueResponse
+  , vrCostValue              :: Maybe CostValueResponse
+  , vrWholesaleValueCurrency :: Maybe WholesaleValueCurrency
+  , vrRetailValue            :: Maybe RetailValueResponse
+  , vrRetailValueCurrency    :: Maybe RetailValueCurrency
   } deriving (Eq, Show)
 
 data Values = Values
@@ -4576,11 +4576,11 @@ instance FromJSON ValuesResource where
     where
       parse o = ValuesResource
                 <$> o .:? "costValueCurrency"
-                <*> o .:  "wholesaleValue"
-                <*> o .:  "costValue"
-                <*> o .:  "wholesaleValueCurrency"
-                <*> o .:  "retailValue"
-                <*> o .:  "retailValueCurrency"
+                <*> o .:? "wholesaleValue"
+                <*> o .:? "costValue"
+                <*> o .:? "wholesaleValueCurrency"
+                <*> o .:? "retailValue"
+                <*> o .:? "retailValueCurrency"
 
 newtype WholesaleValueCurrency = WholesaleValueCurrency
   { unWholesaleValueCurrency :: Text

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -872,9 +872,16 @@ instance FromJSON Error where
                 <*> o .: "message"
                 <*> o .: "type"
 
-newtype ErrorCode = ErrorCode
-  { unErrorCode :: Text
-  } deriving (Eq, Show, FromJSON)
+-- newtype ErrorCode = ErrorCode
+--   { unErrorCode :: Integer
+--   } deriving (Eq, Show, FromJSON)
+
+data ErrorCode = ErrorCodeText Text
+  | ErrorCodeInteger Integer
+  deriving (Eq, Show)
+
+instance FromJSON ErrorCode where
+  parseJSON o = (ErrorCodeText <$> parseJSON o) <|> (ErrorCodeInteger <$> parseJSON o)
 
 newtype ErrorMessage = ErrorMessage
   { unErrorMessage :: Text

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -516,6 +516,9 @@ module Ballast.Types
   , Success(..)
   , ModifyProductsRequest
   , ModifyProductsResponse(..)
+  , GetProductRequest
+  , GetProductResponse(..)
+  , GetProductResponseResource(..)
   ) where
 
 import           Control.Applicative ((<|>))
@@ -3193,9 +3196,37 @@ type CreateProductsResponse = GetProductsResponse
 data ModifyProductsRequest
 type instance ShipwireReturn ModifyProductsRequest = ModifyProductsResponse
 
+-- | GET /api/v3/products/{id}
+data GetProductRequest
+type instance ShipwireReturn GetProductRequest = GetProductResponse
+
 -- | POST /api/v3/products/retire
 data RetireProductsRequest
 type instance ShipwireReturn RetireProductsRequest = RetireProductsResponse
+
+data GetProductResponse = GetProductResponse
+  { gpreStatus           :: ResponseStatus
+  , gpreResourceLocation :: Maybe ResponseResourceLocation
+  , gpreMessage          :: ResponseMessage
+  , gpreResource         :: Maybe GetProductResponseResource
+  , gpreWarnings         :: Maybe ResponseWarnings
+  , gpreErrors           :: Maybe ResponseErrors
+  } deriving (Eq, Show)
+
+instance FromJSON GetProductResponse where
+  parseJSON = withObject "GetProductResponse" parse
+    where
+      parse o = GetProductResponse
+                <$> o .:  "status"
+                <*> o .:? "resourceLocation"
+                <*> o .:  "message"
+                <*> o .:? "resource"
+                <*> o .:? "warnings"
+                <*> o .:? "errors"
+
+newtype GetProductResponseResource = GetProductResponseResource
+  { gprrProductWrapper :: ProductsWrapper
+  } deriving (Eq, Show, FromJSON)
 
 data ModifyProductsResponse = ModifyProductsResponse
   { mprStatus           :: ResponseStatus

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -23,6 +23,7 @@ module Ballast.Types
   , City(..)
   , PostalCode(..)
   , Region(..)
+  , IgnoreUnknownSkus(..)
   , Country(..)
   , Currency(..)
   , GroupBy(..)
@@ -503,19 +504,35 @@ instance ToJSON GetRate where
                                ,"order"   .= rateOrder]
 
 data RateOptions = RateOptions
-  { rateOptionCurrency      :: Currency
-  , rateOptionGroupBy       :: GroupBy
-  , rateOptionCanSplit      :: CanSplit
-  , rateOptionWarehouseArea :: WarehouseArea
-  , rateOptionChannelName   :: Maybe ChannelName
+  { rateOptionCurrency            :: Currency
+  , rateOptionGroupBy             :: GroupBy
+  , rateOptionWarehouseId         :: Maybe WarehouseId
+  , rateOptionWarehouseExternalId :: Maybe WarehouseExternalId
+  , rateOptionWarehouseRegion     :: Maybe WarehouseRegion
+  , rateOptionIgnoreUnknownSkus   :: Maybe IgnoreUnknownSkus
+  , rateOptionCanSplit            :: CanSplit
+  , rateOptionWarehouseArea       :: WarehouseArea
+  , rateOptionChannelName         :: Maybe ChannelName
   } deriving (Eq, Show)
 
+data IgnoreUnknownSkus = IgnoreUnknownSkus
+  | DontIgnoreUnknownSkus
+  deriving (Eq, Show)
+
+instance ToJSON IgnoreUnknownSkus where
+  toJSON IgnoreUnknownSkus     = Number 1
+  toJSON DontIgnoreUnknownSkus = Number 0
+
 instance ToJSON RateOptions where
-  toJSON RateOptions {..} = omitNulls ["currency"      .= rateOptionCurrency
-                                      ,"groupBy"       .= rateOptionGroupBy
-                                      ,"canSplit"      .= rateOptionCanSplit
-                                      ,"warehouseArea" .= rateOptionWarehouseArea
-                                      ,"channelName"   .= rateOptionChannelName]
+  toJSON RateOptions {..} = omitNulls ["currency"            .= rateOptionCurrency
+                                      ,"groupBy"             .= rateOptionGroupBy
+                                      ,"warehouseId"         .= rateOptionWarehouseId
+                                      ,"warehouseExternalId" .= rateOptionWarehouseExternalId
+                                      ,"warehouseRegion"     .= rateOptionWarehouseRegion
+                                      ,"ignoreUnknownSkus"   .= rateOptionIgnoreUnknownSkus
+                                      ,"canSplit"            .= rateOptionCanSplit
+                                      ,"warehouseArea"       .= rateOptionWarehouseArea
+                                      ,"channelName"         .= rateOptionChannelName]
 
 newtype CanSplit = CanSplit
   { unCanSplit :: Integer

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -321,17 +321,19 @@ module Ballast.Types
   , GetProductsResponseResourceItems(..)
   , GetProductsResponseResourceItem(..)
   , ProductsWrapper(..)
-  , BaseProductResource(..)
+  , BaseProductResponseResource(..)
   , TechnicalData(..)
   , TechnicalDataResource(..)
   , NumberOfBatteries(..)
   , BatteryType(..)
   , NumberOfCells(..)
+  , BatteryWeightResponse(..)
   , BatteryWeight(..)
+  , CapacityResponse(..)
   , Capacity(..)
   , CapacityUnit(..)
   , StorageConfiguration(..)
-  , CountryOfOrigin
+  , CountryOfOrigin(..)
   , HsCode(..)
   , CreationDate
   , Flags(..)
@@ -350,11 +352,11 @@ module Ballast.Types
   , IsMedia(..)
   , Category(..)
   , Status(..)
-  , AlternateNames(..)
-  , AlternateNamesResource(..)
-  , AlternateNamesResourceItems(..)
-  , AlternateNamesResourceItem(..)
-  , AlternateNamesResourceItemResource(..)
+  , AlternateNamesResponse(..)
+  , AlternateNamesResponseResource(..)
+  , AlternateNamesResponseResourceItems(..)
+  , AlternateNamesResponseResourceItem(..)
+  , AlternateNamesResponseResourceItemResource(..)
   , Pallet(..)
   , PalletResource
   , InnerPack(..)
@@ -365,8 +367,8 @@ module Ballast.Types
   , ArchivedDate
   , Classification(..)
   , BatteryConfiguration(..)
-  , BaseProductMasterCase(..)
-  , BaseProductMasterCaseResource(..)
+  , BaseProductResponseMasterCase(..)
+  , BaseProductResponseMasterCaseResource(..)
   , Dimensions(..)
   , DimensionsResource(..)
   , DimensionsWeight(..)
@@ -377,19 +379,19 @@ module Ballast.Types
   , WidthUnit
   , DimensionsLength(..)
   , LengthUnit
-  , Values(..)
+  , ValuesResponse(..)
   , ValuesResource(..)
-  , CostValueCurrency
-  , WholesaleValueCurrency
-  , RetailValueCurrency
+  , Values(..)
+  , CostValueCurrency(..)
+  , WholesaleValueCurrency(..)
+  , RetailValueCurrency(..)
+  , CostValueResponse(..)
   , CostValue(..)
-  , WholesaleValue
-  , RetailValue
   , IndividualItemsPerCase(..)
   , MasterCaseFlags(..)
   , MasterCaseFlagsResource(..)
   , IsPackagedReadyToShip(..)
-  , MarketingInsertResource(..)
+  , MarketingInsertResponseResource(..)
   , MarketingInsertMasterCase(..)
   , MarketingInsertMasterCaseResource(..)
   , InclusionRuleType(..)
@@ -403,14 +405,14 @@ module Ballast.Types
   , InclusionRulesResourceFlags(..)
   , MarketingInsertFlags(..)
   , MarketingInsertFlagsResource(..)
-  , VirtualKitResource(..)
+  , VirtualKitResponseResource(..)
   , VirtualKitContent(..)
   , VirtualKitContentResource(..)
   , VirtualKitContentResourceItems(..)
   , VirtualKitContentResourceItem(..)
   , VirtualKitContentResourceItemResource(..)
   , VirtualKitFlags(..)
-  , KitResource(..)
+  , KitResponseResource(..)
   , KitMasterCase
   , KitTechnicalData(..)
   , KitTechnicalDataResource(..)
@@ -433,6 +435,35 @@ module Ballast.Types
   , flowParamToBS
   , IdsParam(..)
   , SkusParam(..)
+  , CreateProductsRequest
+  , CreateProductsResponse
+  , CreateProductsWrapper(..)
+  , BaseProduct(..)
+  , BaseProductPallet(..)
+  , BaseProductMasterCase(..)
+  , BaseProductInnerPack(..)
+  , BaseProductAlternateNames(..)
+  , BaseProductAlternateName(..)
+  , BaseProductFlags(..)
+  , BaseProductPalletFlags(..)
+  , BaseProductMasterCaseFlags(..)
+  , BaseProductInnerPackFlags(..)
+  , BaseProductTechnicalData(..)
+  , BaseProductTechnicalDataResource(..)
+  , BaseProductDimensions(..)
+  , BaseProductLength(..)
+  , BaseProductWidth(..)
+  , BaseProductHeight(..)
+  , BaseProductWeight(..)
+  , RetailCurrency(..)
+  , WholesaleCurrency(..)
+  , RetailValue(..)
+  , RetailValueResponse(..)
+  , WholesaleValue(..)
+  , WholesaleValueResponse(..)
+  -- , MarketingInsert(..)
+  -- , VirtualKit(..)
+  -- , Kit(..)
   ) where
 
 import           Data.Aeson
@@ -977,7 +1008,7 @@ instance FromJSON Cost where
 
 newtype CostCurrency = CostCurrency
   { unCostCurrency :: Text
-  } deriving (Eq, Show, FromJSON)
+  } deriving (Eq, Show, ToJSON, FromJSON)
 
 newtype CostType = CostType
   { unCostType :: Text
@@ -2651,7 +2682,7 @@ type ExternalOrderId = ExternalId
 
 newtype Description = Description
   { unDescription :: Text
-  } deriving (Eq, Show, FromJSON)
+  } deriving (Eq, Show, ToJSON, FromJSON)
 
 type ClearedDate = ExpectedShipDate
 
@@ -3088,6 +3119,220 @@ instance ShipwireHasParam GetProductsRequest FlowParams
 instance ShipwireHasParam GetProductsRequest IdsParam
 instance ShipwireHasParam GetProductsRequest SkusParam
 
+-- | POST /api/v3/products
+data CreateProductsRequest
+type instance ShipwireReturn CreateProductsRequest = CreateProductsResponse
+
+type CreateProductsResponse = GetProductsResponse
+
+-- | You can create multiple products of different classifications at the same time
+-- by passing them inside a JSON array. To distinguish between different ToJSON instances
+-- we use this wrapper datatype.
+data CreateProductsWrapper = CpwBaseProduct BaseProduct
+  -- | CpwMarketingInsert MarketingInsert
+  -- | CpwVirtualKit VirtualKit
+  -- | CpwKit Kit
+  deriving (Eq, Show)
+
+instance ToJSON CreateProductsWrapper where
+  toJSON (CpwBaseProduct x)     = toJSON x
+  -- toJSON (CpwMarketingInsert x) = toJSON x
+  -- toJSON (CpwVirtualKit x)      = toJSON x
+  -- toJSON (CpwKit x)             = toJSON x
+
+
+data BaseProduct = BaseProduct
+  { bpSku                  :: SKU
+  , bpExternalId           :: Maybe ExternalId
+  , bpClassification       :: Classification
+  , bpDescription          :: Description
+  , bpHsCode               :: Maybe HsCode
+  , bpCountryOfOrigin      :: CountryOfOrigin
+  , bpCategory             :: Category
+  , bpBatteryConfiguration :: BatteryConfiguration
+  , bpValues               :: Values
+  , bpAlternateNames       :: BaseProductAlternateNames
+  , bpDimensions           :: BaseProductDimensions
+  , bpTechnicalData        :: BaseProductTechnicalData
+  , bpFlags                :: BaseProductFlags
+  , bpInnerPack            :: BaseProductInnerPack
+  , bpMasterCase           :: BaseProductMasterCase
+  , bpPallet               :: BaseProductPallet
+  } deriving (Eq, Show)
+
+instance ToJSON BaseProduct where
+  toJSON BaseProduct {..} = omitNulls ["sku"                  .= bpSku
+                                      ,"externalId"           .= bpExternalId
+                                      ,"classification"       .= bpClassification
+                                      ,"description"          .= bpDescription
+                                      ,"hsCode"               .= bpHsCode
+                                      ,"countryOfOrigin"      .= bpCountryOfOrigin
+                                      ,"category"             .= bpCategory
+                                      ,"batteryConfiguration" .= bpBatteryConfiguration
+                                      ,"values"               .= bpValues
+                                      ,"alternateNames"       .= bpAlternateNames
+                                      ,"dimensions"           .= bpDimensions
+                                      ,"technicalData"        .= bpTechnicalData
+                                      ,"flags"                .= bpFlags
+                                      ,"innerPack"            .= bpInnerPack
+                                      ,"masterCase"           .= bpMasterCase
+                                      ,"pallet"               .= bpPallet]
+
+data BaseProductPallet = BaseProductPallet
+  { bppIndividualItemsPerCase :: IndividualItemsPerCase
+  , bppExternalid             :: ExternalId
+  , bppSku                    :: SKU
+  , bppDescription            :: Description
+  , bppValues                 :: Values
+  , bppDimensions             :: BaseProductDimensions
+  , bppFlags                  :: BaseProductPalletFlags
+  } deriving (Eq, Show)
+
+instance ToJSON BaseProductPallet where
+  toJSON BaseProductPallet {..} = object ["individualItemsPerCase" .= bppIndividualItemsPerCase
+                                         ,"externalId"             .= bppExternalid
+                                         ,"sku"                    .= bppSku
+                                         ,"description"            .= bppDescription
+                                         ,"values"                 .= bppValues
+                                         ,"dimensions"             .= bppDimensions
+                                         ,"flags"                  .= bppFlags]
+                                          
+newtype BaseProductPalletFlags = BaseProductPalletFlags
+  { bppfIsPackagedReadyToShip :: IsPackagedReadyToShip
+  } deriving (Eq, Show, ToJSON)
+
+data BaseProductMasterCase = BaseProductMasterCase
+  { bpmcIndividualItemsPerCase :: IndividualItemsPerCase
+  , bpmcExternalId             :: ExternalId
+  , bpmcSku                    :: SKU
+  , bpmcDescription            :: Description
+  , bpmcValues                 :: Values
+  , bpmcDimensions             :: BaseProductDimensions
+  , bpmcFlags                  :: BaseProductMasterCaseFlags
+  } deriving (Eq, Show)
+
+instance ToJSON BaseProductMasterCase where
+  toJSON BaseProductMasterCase {..} = object ["individualItemsPerCase" .= bpmcIndividualItemsPerCase
+                                             ,"externalId"             .= bpmcExternalId
+                                             ,"sku"                    .= bpmcSku
+                                             ,"description"            .= bpmcDescription
+                                             ,"values"                 .= bpmcValues
+                                             ,"dimensions"             .= bpmcDimensions
+                                             ,"flags"                  .= bpmcFlags]
+
+newtype BaseProductMasterCaseFlags = BaseProductMasterCaseFlags
+  { bpmcfIsPackagedReadyToShip :: IsPackagedReadyToShip
+  } deriving (Eq, Show, ToJSON)
+
+data BaseProductInnerPack = BaseProductInnerPack
+  { bpipIndividualItemsPerCase :: IndividualItemsPerCase
+  , bpipExternalId             :: ExternalId
+  , bpipSku                    :: SKU
+  , bpipDescription            :: Description
+  , bpipValues                 :: Values
+  , bpipDimensions             :: BaseProductDimensions
+  , bpipFlags                  :: BaseProductInnerPackFlags
+  } deriving (Eq, Show)
+
+instance ToJSON BaseProductInnerPack where
+  toJSON BaseProductInnerPack {..} = object ["individualItemsPerCase" .= bpipIndividualItemsPerCase
+                                            ,"externalId"             .= bpipExternalId
+                                            ,"sku"                    .= bpipSku
+                                            ,"description"            .= bpipDescription
+                                            ,"values"                 .= bpipValues
+                                            ,"dimensions"             .= bpipDimensions
+                                            ,"flags"                  .= bpipFlags]
+
+newtype BaseProductInnerPackFlags = BaseProductInnerPackFlags
+  { bpipfIsPackagedReadyToShip :: IsPackagedReadyToShip
+  } deriving (Eq, Show, ToJSON)
+    
+newtype BaseProductAlternateNames = BaseProductAlternateNames
+  { bpanAlternateNames :: [BaseProductAlternateName]
+  } deriving (Eq, Show, ToJSON)
+
+newtype BaseProductAlternateName = BaseProductAlternateName
+  { bpanName :: Name
+  } deriving (Eq, Show)
+
+instance ToJSON BaseProductAlternateName where
+  toJSON BaseProductAlternateName {..} = object ["name" .= bpanName]
+
+data BaseProductFlags = BaseProductFlags
+  { bpfIsPackagedReadyToShip :: IsPackagedReadyToShip
+  , bpfIsFragile             :: IsFragile
+  , bpfIsDangerous           :: IsDangerous
+  , bpfIsPerishable          :: IsPerishable
+  , bpfIsMedia               :: IsMedia
+  , bpfIsAdult               :: IsAdult
+  , bpfIsLiquid              :: IsLiquid
+  , bpfHasInnerPack          :: HasInnerPack
+  , bpfHasMasterCase         :: HasMasterCase
+  , bpfHasPallet             :: HasPallet
+  } deriving (Eq, Show)
+
+instance ToJSON BaseProductFlags where
+  toJSON BaseProductFlags {..} = object ["isPackagedReadyToShip" .= bpfIsPackagedReadyToShip
+                                        ,"isFragile"             .= bpfIsFragile
+                                        ,"isDangerous"           .= bpfIsDangerous
+                                        ,"isPerishable"          .= bpfIsPerishable
+                                        ,"isMeida"               .= bpfIsMedia
+                                        ,"isAdult"               .= bpfIsAdult
+                                        ,"isLiquid"              .= bpfIsLiquid
+                                        ,"hasInnerPack"          .= bpfHasInnerPack
+                                        ,"hasMasterCase"         .= bpfHasMasterCase
+                                        ,"hasPallet"             .= bpfHasPallet]
+
+newtype BaseProductTechnicalData = BaseProductTechnicalData
+  { unTechnicalDataResource :: BaseProductTechnicalDataResource
+  } deriving (Eq, Show, ToJSON)
+
+data BaseProductTechnicalDataResource = BaseProductTechnicalDataResource
+  { bptdrType              :: BatteryType
+  , bptdrBatteryWeight     :: BatteryWeight
+  , bptdrNumberOfBatteries :: NumberOfBatteries
+  , bptdrCapacity          :: Capacity
+  , bptdrNumberOfCells     :: NumberOfCells
+  , bptdrCapacityUnit      :: CapacityUnit
+  } deriving (Eq, Show)
+
+instance ToJSON BaseProductTechnicalDataResource where
+  toJSON BaseProductTechnicalDataResource {..} = object ["type"              .= bptdrType
+                                                        ,"batteryWeight"     .= bptdrBatteryWeight
+                                                        ,"numberOfBatteries" .= bptdrNumberOfBatteries
+                                                        ,"capacity"          .= bptdrCapacity
+                                                        ,"numberOfCells"     .= bptdrNumberOfCells
+                                                        ,"capacityUnit"      .= bptdrCapacityUnit]
+
+data BaseProductDimensions = BaseProductDimensions
+  { bpdLength :: BaseProductLength
+  , bpdWidth  :: BaseProductWidth
+  , bpdHeight :: BaseProductHeight
+  , bpdWeight :: BaseProductWeight
+  } deriving (Eq, Show)
+
+instance ToJSON BaseProductDimensions where
+  toJSON BaseProductDimensions {..} = object ["length" .= bpdLength
+                                             ,"width"  .= bpdWidth
+                                             ,"height" .= bpdHeight
+                                             ,"weight" .= bpdWeight]
+
+newtype BaseProductLength = BaseProductLength
+  { unBaseProductLength :: Integer
+  } deriving (Eq, Show, ToJSON)
+
+newtype BaseProductWidth = BaseProductWidth
+  { unBaseProductWidth :: Integer
+  } deriving (Eq, Show, ToJSON)
+
+newtype BaseProductHeight = BaseProductHeight
+  { unBaseProductHeight :: Integer
+  } deriving (Eq, Show, ToJSON)
+
+newtype BaseProductWeight = BaseProductWeight
+  { unBaseProductWeight :: Integer
+  } deriving (Eq, Show, ToJSON)
+
 newtype SkusParam = SkusParam
   { unSkusParam :: [BS8.ByteString]
   } deriving (Eq, Show)
@@ -3289,23 +3534,24 @@ instance FromJSON GetProductsResponseResourceItem where
       parse o = GetProductsResponseResourceItem
                 <$> o .: "resourceLocation"
                 <*> o .: "resource"
+
                 
 -- | This a wrapper for different classifications of products.
 -- Possible options are: baseProduct, marketingInsert, virtualKit, kit.
-data ProductsWrapper = PwBaseProduct BaseProductResource
-  | PwMarketingInsert MarketingInsertResource
-  | PwVirtualKit VirtualKitResource
-  | PwKit KitResource
+data ProductsWrapper = PwBaseProduct BaseProductResponseResource
+  | PwMarketingInsert MarketingInsertResponseResource
+  | PwVirtualKit VirtualKitResponseResource
+  | PwKit KitResponseResource
   deriving (Eq, Show)
 
 instance FromJSON ProductsWrapper where
-  parseJSON (Object v) = piwValue
+  parseJSON (Object v) = pwValue
     where
       isBaseProduct     = HM.lookup "classification" v == Just "baseProduct"
       isMarketingInsert = HM.lookup "classification" v == Just "marketingInsert"
       isVirtualKit      = HM.lookup "classification" v == Just "virtualKit"
       isKit             = HM.lookup "classification" v == Just "kit"
-      piwValue          = parseProductsWrapper isBaseProduct isMarketingInsert isVirtualKit isKit v
+      pwValue          = parseProductsWrapper isBaseProduct isMarketingInsert isVirtualKit isKit v
   parseJSON _ = mempty
 
 parseProductsWrapper :: Bool -> Bool -> Bool -> Bool -> Object -> Parser ProductsWrapper
@@ -3316,7 +3562,7 @@ parseProductsWrapper isBaseProduct isMarketingInsert isVirtualKit isKit value
   | isKit             = PwKit             <$> parseKit value
   | otherwise         = PwBaseProduct     <$> parseBaseProduct value
 
-data KitResource = KitResource
+data KitResponseResource = KitResponseResource
   { krId                   :: Id
   , krExternalId           :: Maybe ExternalId
   , krSku                  :: SKU
@@ -3332,8 +3578,8 @@ data KitResource = KitResource
   , krCategory             :: Maybe Category
   , krItemCount            :: ItemCount
   , krDimensions           :: Dimensions
-  , krValues               :: Values
-  , krAlternateNames       :: AlternateNames
+  , krValues               :: ValuesResource
+  , krAlternateNames       :: AlternateNamesResponse
   , krKitContent           :: Maybe KitContent
   , krTechnicalData        :: Maybe KitTechnicalData
   , krFlags                :: Flags
@@ -3343,12 +3589,12 @@ data KitResource = KitResource
   , krPallet               :: Maybe Pallet
   } deriving (Eq, Show)
 
-instance FromJSON KitResource where
+instance FromJSON KitResponseResource where
   parseJSON (Object o) = parseKit o
   parseJSON _          = mempty
 
-parseKit :: Object -> Parser KitResource
-parseKit o = KitResource
+parseKit :: Object -> Parser KitResponseResource
+parseKit o = KitResponseResource
              <$> o .:  "id"
              <*> o .:? "externalId"
              <*> o .:  "sku"
@@ -3374,7 +3620,7 @@ parseKit o = KitResource
              <*> o .:? "masterCase"
              <*> o .:? "pallet"
 
-type KitMasterCase = BaseProductMasterCase
+type KitMasterCase = BaseProductResponseMasterCase
 
 data KitTechnicalData = KitTechnicalData
   { ktdResourceLocation :: Maybe ResponseResourceLocation
@@ -3408,7 +3654,7 @@ type KitTechnicalDataResourceBatteryResource = TechnicalDataResource
 
 type KitContent = VirtualKitContent
 
-data VirtualKitResource = VirtualKitResource
+data VirtualKitResponseResource = VirtualKitResponseResource
   { vkrId                :: Id
   , vkrExternalId        :: Maybe ExternalId
   , vkrClassification    :: Classification
@@ -3420,12 +3666,12 @@ data VirtualKitResource = VirtualKitResource
   , vkrFlags             :: VirtualKitFlags
   } deriving (Eq, Show)
 
-instance FromJSON VirtualKitResource where
+instance FromJSON VirtualKitResponseResource where
   parseJSON (Object o) = parseVirtualKit o
   parseJSON _          = mempty
 
-parseVirtualKit :: Object -> Parser VirtualKitResource
-parseVirtualKit o = VirtualKitResource
+parseVirtualKit :: Object -> Parser VirtualKitResponseResource
+parseVirtualKit o = VirtualKitResponseResource
                     <$> o .:  "id"
                     <*> o .:? "externalId"
                     <*> o .:  "classification"
@@ -3506,7 +3752,7 @@ instance FromJSON VirtualKitFlags where
       parse o = VirtualKitFlags
                 <$> o .:? "resourceLocation"
 
-data MarketingInsertResource = MarketingInsertResource
+data MarketingInsertResponseResource = MarketingInsertResponseResource
   { mirId                   :: Id
   , mirExternalId           :: Maybe ExternalId
   , mirSku                  :: SKU
@@ -3519,18 +3765,18 @@ data MarketingInsertResource = MarketingInsertResource
   , mirClassificaion        :: Classification
   , mirItemCount            :: ItemCount
   , mirDimensions           :: Dimensions
-  , mirAlternateNames       :: AlternateNames
+  , mirAlternateNames       :: AlternateNamesResponse
   , mirFlags                :: Maybe MarketingInsertFlags
   , mirInclusionRules       :: Maybe InclusionRules
   , mirMasterCase           :: Maybe MarketingInsertMasterCase
   } deriving (Eq, Show)
 
-instance FromJSON MarketingInsertResource where
+instance FromJSON MarketingInsertResponseResource where
   parseJSON (Object o) = parseMarketingInsert o
   parseJSON _          = mempty
 
-parseMarketingInsert :: Object -> Parser MarketingInsertResource
-parseMarketingInsert o = MarketingInsertResource
+parseMarketingInsert :: Object -> Parser MarketingInsertResponseResource
+parseMarketingInsert o = MarketingInsertResponseResource
                          <$> o .:  "id"
                          <*> o .:? "externalId"
                          <*> o .:  "sku"
@@ -3619,6 +3865,7 @@ instance FromJSON InclusionRulesResource where
                 <*> o .:? "flags"
 
 type InsertAfterDate = ExpectedDateUTCTime
+
 type InsertBeforeDate = ExpectedDateUTCTime
 
 newtype InsertWhenWorthValue = InsertWhenWorthValue
@@ -3626,6 +3873,7 @@ newtype InsertWhenWorthValue = InsertWhenWorthValue
   } deriving (Eq, Show, FromJSON)
 
 type InsertWhenWorthValueCurrency = CostCurrency
+
 type InsertWhenQuantity = Quantity
 
 newtype InclusionRulesResourceFlags = InclusionRulesResourceFlags
@@ -3662,10 +3910,10 @@ instance FromJSON MarketingInsertFlagsResource where
                 <*> o .: "isDeletable"
                 <*> o .: "hasEditRestrictions"
 
-data BaseProductResource = BaseProductResource
+data BaseProductResponseResource = BaseProductResponseResource
   { bprClassification       :: Classification
   , bprBatteryConfiguration :: Maybe BatteryConfiguration
-  , bprMasterCase           :: Maybe BaseProductMasterCase
+  , bprMasterCase           :: Maybe BaseProductResponseMasterCase
   , bprItemCount            :: ItemCount
   , bprId                   :: Id
   , bprSku                  :: SKU
@@ -3675,10 +3923,12 @@ data BaseProductResource = BaseProductResource
   , bprInnerPack            :: Maybe InnerPack
   , bprPallet               :: Maybe Pallet
   , bprExternalId           :: Maybe ExternalId
-  , bprAlternateNames       :: AlternateNames
-  , bprValues               :: Values
+  , bprAlternateNames       :: AlternateNamesResponse
+  , bprValues               :: ValuesResponse
   , bprStatus               :: Status
   , bprCategory             :: Maybe Category
+  , bprVendorId             :: Maybe VendorId
+  , bprVendorExternalid     :: Maybe VendorExternalId
   , bprDescription          :: Description
   , bprFlags                :: Flags
   , bprCreationDate         :: CreationDate
@@ -3688,12 +3938,16 @@ data BaseProductResource = BaseProductResource
   , bprTechnicalData        :: Maybe TechnicalData
   } deriving (Eq, Show)
 
-instance FromJSON BaseProductResource where
+type VendorId = Id
+
+type VendorExternalId = ExternalId
+
+instance FromJSON BaseProductResponseResource where
   parseJSON (Object o) = parseBaseProduct o
   parseJSON _          = mempty
 
-parseBaseProduct :: Object -> Parser BaseProductResource
-parseBaseProduct o = BaseProductResource
+parseBaseProduct :: Object -> Parser BaseProductResponseResource
+parseBaseProduct o = BaseProductResponseResource
                      <$> o .:  "classification"      
                      <*> o .:? "batteryConfiguration"
                      <*> o .:? "masterCase"          
@@ -3709,7 +3963,9 @@ parseBaseProduct o = BaseProductResource
                      <*> o .:  "alternateNames"      
                      <*> o .:  "values"              
                      <*> o .:  "status"              
-                     <*> o .:? "category"            
+                     <*> o .:? "category"
+                     <*> o .:? "vendorId"
+                     <*> o .:? "vendorExternalId"
                      <*> o .:  "description"         
                      <*> o .:  "flags"               
                      <*> o .:  "creationDate"        
@@ -3732,8 +3988,8 @@ instance FromJSON TechnicalData where
 
 data TechnicalDataResource = TechnicalDataResource
   { tdrCapacityUnit      :: Maybe CapacityUnit
-  , tdrCapacity          :: Capacity
-  , tdrBatteryWeight     :: BatteryWeight
+  , tdrCapacity          :: CapacityResponse
+  , tdrBatteryWeight     :: BatteryWeightResponse
   , tdrNumberOfCells     :: NumberOfCells
   , tdrType              :: BatteryType
   , tdrNumberOfBatteries :: NumberOfBatteries
@@ -3754,28 +4010,36 @@ instance FromJSON TechnicalDataResource where
 
 newtype NumberOfBatteries = NumberOfBatteries
   { unNumberOfBatteries :: Integer
-  } deriving (Eq, Show, FromJSON)
+  } deriving (Eq, Show, ToJSON, FromJSON)
 
 newtype BatteryType = BatteryType
   { unBatteryType :: Text
-  } deriving (Eq, Show, FromJSON)
+  } deriving (Eq, Show, ToJSON, FromJSON)
 
 newtype NumberOfCells = NumberOfCells
   { unNumberOfCells :: Integer
+  } deriving (Eq, Show, ToJSON, FromJSON)
+
+newtype BatteryWeightResponse = BatteryWeightResponse
+  { unBatteryWeightR :: Text
   } deriving (Eq, Show, FromJSON)
 
 newtype BatteryWeight = BatteryWeight
-  { unBatteryWeight :: Text
-  } deriving (Eq,  Show, FromJSON)
+  { unBatteryWeight :: Integer
+  } deriving (Eq, Show, ToJSON)
+
+newtype CapacityResponse = CapacityResponse
+  { unCapacityR :: Text
+  } deriving (Eq, Show, FromJSON)
 
 newtype Capacity = Capacity
-  { unCapacity :: Text
-  } deriving (Eq, Show, FromJSON)
+  { unCapacity :: Integer
+  } deriving (Eq, Show, ToJSON)
 
 -- It's not specified in the docs what type this should be.
 newtype CapacityUnit = CapacityUnit
   { unCapacityUnit :: Text
-  } deriving (Eq, Show, FromJSON)
+  } deriving (Eq, Show, ToJSON, FromJSON)
 
 data StorageConfiguration = IndividualItemConfiguration
   | InnerPackConfiguration
@@ -3794,11 +4058,9 @@ instance FromJSON StorageConfiguration where
       parse "KIT"             = pure KitConfiguration
       parse _                = error "Bad input"
 
-type CountryOfOrigin = Country
-
 newtype HsCode = HsCode
   { unHsCode :: Text
-  } deriving (Eq, Show, FromJSON)
+  } deriving (Eq, Show, ToJSON, FromJSON)
 
 type CreationDate = ExpectedDateUTCTime
 
@@ -3857,7 +4119,11 @@ instance FromJSON IsAdult where
     where
       parse 0 = pure NotAdult
       parse 1 = pure Adult
-      parse _ = error "Bad value"      
+      parse _ = error "Bad value"
+
+instance ToJSON IsAdult where
+  toJSON NotAdult = Number 0
+  toJSON Adult    = Number 1
 
 data HasInnerPack = HasInnerPack
   | NoInnerPack
@@ -3868,7 +4134,11 @@ instance FromJSON HasInnerPack where
     where
       parse 0 = pure NoInnerPack
       parse 1 = pure HasInnerPack
-      parse _ = error "Bad value"      
+      parse _ = error "Bad value"
+
+instance ToJSON HasInnerPack where
+  toJSON NoInnerPack  = Number 0
+  toJSON HasInnerPack = Number 1
 
 data HasEditRestrictions = EditRestrictions
   | NoEditRestrictions
@@ -3890,7 +4160,11 @@ instance FromJSON IsPerishable where
     where
       parse 0 = pure NotPerishable
       parse 1 = pure Perishable
-      parse _ = error "Bad value"      
+      parse _ = error "Bad value"
+
+instance ToJSON IsPerishable where
+  toJSON NotPerishable = Number 0
+  toJSON Perishable    = Number 1
  
 data IsDangerous = Dangerous
   | NotDangerous
@@ -3901,7 +4175,11 @@ instance FromJSON IsDangerous where
     where
       parse 0 = pure NotDangerous
       parse 1 = pure Dangerous
-      parse _ = error "Bad value"      
+      parse _ = error "Bad value"
+
+instance ToJSON IsDangerous where
+  toJSON NotDangerous = Number 0
+  toJSON Dangerous    = Number 1
 
 data IsLiquid = Liquid
   | NotLiquid
@@ -3912,7 +4190,11 @@ instance FromJSON IsLiquid where
     where
       parse 0 = pure NotLiquid
       parse 1 = pure Liquid
-      parse _ = error "Bad value"      
+      parse _ = error "Bad value"
+
+instance ToJSON IsLiquid where
+  toJSON NotLiquid = Number 0
+  toJSON Liquid    = Number 1
 
 data IsArchivable = Archivable
   | NotArchivable
@@ -3934,7 +4216,11 @@ instance FromJSON IsFragile where
     where
       parse 0 = pure NotFragile
       parse 1 = pure Fragile
-      parse _ = error "Bad value"      
+      parse _ = error "Bad value"
+
+instance ToJSON IsFragile where
+  toJSON NotFragile = Number 0
+  toJSON Fragile    = Number 1
 
 data HasMasterCase = HasMasterCase
   | NoMasterCase
@@ -3945,7 +4231,11 @@ instance FromJSON HasMasterCase where
     where
       parse 0 = pure NoMasterCase
       parse 1 = pure HasMasterCase
-      parse _ = error "Bad value"      
+      parse _ = error "Bad value"
+
+instance ToJSON HasMasterCase where
+  toJSON NoMasterCase  = Number 0
+  toJSON HasMasterCase = Number 1
 
 data HasPallet = HasPallet
   | NoPallet
@@ -3956,7 +4246,11 @@ instance FromJSON HasPallet where
     where
       parse 0 = pure NoPallet
       parse 1 = pure HasPallet
-      parse _ = error "Bad value"      
+      parse _ = error "Bad value"
+
+instance ToJSON HasPallet where
+  toJSON NoPallet  = Number 0
+  toJSON HasPallet = Number 1
 
 data IsDeletable = Deletable
   | NotDeletable
@@ -3980,70 +4274,74 @@ instance FromJSON IsMedia where
       parse 1 = pure Media
       parse _ = error "Bad value"
 
+instance ToJSON IsMedia where
+  toJSON NotMedia = Number 0
+  toJSON Media    = Number 1
+
 newtype Category = Category
   { unCategory :: Text
-  } deriving (Eq, Show, FromJSON)
+  } deriving (Eq, Show, ToJSON, FromJSON)
 
 newtype Status = Status
   { unStatus :: Text
   } deriving (Eq, Show, FromJSON)
 
-data AlternateNames = AlternateNames
+data AlternateNamesResponse = AlternateNamesResponse
   { anResourceLocation :: Maybe ResponseResourceLocation
-  , anResource         :: Maybe AlternateNamesResource
+  , anResource         :: Maybe AlternateNamesResponseResource
   } deriving (Eq, Show)
 
-instance FromJSON AlternateNames where
+instance FromJSON AlternateNamesResponse where
   parseJSON = withObject "AlternateNames" parse
     where
-      parse o = AlternateNames
+      parse o = AlternateNamesResponse
                 <$> o .:? "resourceLocation"
                 <*> o .:? "resource"
 
-data AlternateNamesResource = AlternateNamesResource
+data AlternateNamesResponseResource = AlternateNamesResponseResource
   { anrPrevious :: Maybe Previous
   , anrNext     :: Maybe Next
   , anrTotal    :: Total
-  , anrItems    :: AlternateNamesResourceItems
+  , anrItems    :: AlternateNamesResponseResourceItems
   , anrOffset   :: Offset
   } deriving (Eq, Show)
 
-instance FromJSON AlternateNamesResource where
+instance FromJSON AlternateNamesResponseResource where
   parseJSON = withObject "AlternateNamesResource" parse
     where
-      parse o = AlternateNamesResource
+      parse o = AlternateNamesResponseResource
                 <$> o .:? "previous"
                 <*> o .:? "next"
                 <*> o .:  "total"
                 <*> o .:  "items"
                 <*> o .:  "offset"
 
-newtype AlternateNamesResourceItems = AlternateNamesResourceItems
-  { anriItems :: [AlternateNamesResourceItem]
+newtype AlternateNamesResponseResourceItems = AlternateNamesResponseResourceItems
+  { anriItems :: [AlternateNamesResponseResourceItem]
   } deriving (Eq, Show, FromJSON)
 
-data AlternateNamesResourceItem = AlternateNamesResourceItem
+data AlternateNamesResponseResourceItem = AlternateNamesResponseResourceItem
   { anriResourceLocation :: Maybe ResponseResourceLocation
-  , anriResource         :: AlternateNamesResourceItemResource
+  , anriResource         :: AlternateNamesResponseResourceItemResource
   } deriving (Eq, Show)
 
-instance FromJSON AlternateNamesResourceItem where
+instance FromJSON AlternateNamesResponseResourceItem where
   parseJSON = withObject "AlternateNamesResourceItem" parse
     where
-      parse o = AlternateNamesResourceItem
+      parse o = AlternateNamesResponseResourceItem
                 <$> o .:? "resourceLocation"
                 <*> o .:  "resource"
 
-data AlternateNamesResourceItemResource = AlternateNamesResourceItemResource
+data AlternateNamesResponseResourceItemResource = AlternateNamesResponseResourceItemResource
   { anrirExternalid :: Maybe ExternalId
   , anrirName       :: Name
   , anrirProductId  :: ProductId
   } deriving (Eq, Show)
 
-instance FromJSON AlternateNamesResourceItemResource where
+instance FromJSON AlternateNamesResponseResourceItemResource where
   parseJSON = withObject "AlternateNamesResourceItemResource" parse
     where
-      parse o = AlternateNamesResourceItemResource
+      parse o = AlternateNamesResponseResourceItemResource
                 <$> o .:? "externalId"
                 <*> o .:  "name"
                 <*> o .:  "productId"
@@ -4060,7 +4358,7 @@ instance FromJSON Pallet where
                 <$> o .:? "resourceLocation"
                 <*> o .:? "resource"
 
-type PalletResource = BaseProductMasterCaseResource
+type PalletResource = BaseProductResponseMasterCaseResource
 
 data InnerPack = InnerPack
   { ipResourceLocation :: Maybe ResponseResourceLocation
@@ -4074,7 +4372,7 @@ instance FromJSON InnerPack where
                 <$> o .:? "resourceLocation"
                 <*> o .:? "resource"
 
-type InnerPackResource = BaseProductMasterCaseResource
+type InnerPackResource = BaseProductResponseMasterCaseResource
 
 data EnqueuedDimensions = EnqueuedDimensions
   { edResourceLocation :: Maybe ResponseResourceLocation
@@ -4114,41 +4412,47 @@ newtype ItemCount = ItemCount
 
 type ArchivedDate = ExpectedDateUTCTime
 
-data Classification = BaseProduct
-  | MarketingInsert
-  | VirtualKit
-  | Kit
+data Classification = BaseProductClassification
+  | MarketingInsertClassification
+  | VirtualKitClassification
+  | KitClassification
   deriving (Eq, Show)
+
+instance ToJSON Classification where
+  toJSON BaseProductClassification     = String "baseProduct"
+  toJSON MarketingInsertClassification = String "marketingInsert"
+  toJSON VirtualKitClassification      = String "virtualKit"
+  toJSON KitClassification             = String "kit"
 
 instance FromJSON Classification where
   parseJSON = withText "classification" parse
     where
-      parse "baseProduct"     = pure BaseProduct
-      parse "marketingInsert" = pure MarketingInsert
-      parse "virtualKit"      = pure VirtualKit
-      parse "kit"             = pure Kit
+      parse "baseProduct"     = pure BaseProductClassification
+      parse "marketingInsert" = pure MarketingInsertClassification
+      parse "virtualKit"      = pure VirtualKitClassification
+      parse "kit"             = pure KitClassification
       parse _                 = error "Bad input"
 
 newtype BatteryConfiguration = BatteryConfiguration
   { unBatteryConfiguration :: Text
-  } deriving (Eq, Show, FromJSON)
+  } deriving (Eq, Show, ToJSON, FromJSON)
 
-data BaseProductMasterCase = BaseProductMasterCase
+data BaseProductResponseMasterCase = BaseProductResponseMasterCase
   { mcResourceLocation :: Maybe ResponseResourceLocation
-  , mcResource         :: Maybe BaseProductMasterCaseResource
+  , mcResource         :: Maybe BaseProductResponseMasterCaseResource
   } deriving (Eq, Show)
 
-instance FromJSON BaseProductMasterCase where
+instance FromJSON BaseProductResponseMasterCase where
   parseJSON = withObject "MasterCase" parse
     where
-      parse o = BaseProductMasterCase
+      parse o = BaseProductResponseMasterCase
                 <$> o .:? "resourceLocation"
                 <*> o .:? "resource"
 
-data BaseProductMasterCaseResource = BaseProductMasterCaseResource
+data BaseProductResponseMasterCaseResource = BaseProductResponseMasterCaseResource
   { mcrSku                    :: SKU
   , mcrDimensions             :: Dimensions
-  , mcrValues                 :: Values
+  , mcrValues                 :: ValuesResource
   , mcrExternalId             :: ExternalId
   , mcrIndividualItemsPerCase :: IndividualItemsPerCase
   , mcrFlags                  :: MasterCaseFlags
@@ -4156,10 +4460,10 @@ data BaseProductMasterCaseResource = BaseProductMasterCaseResource
   , mcrDescription            :: Description
   } deriving (Eq, Show)
 
-instance FromJSON BaseProductMasterCaseResource where
+instance FromJSON BaseProductResponseMasterCaseResource where
   parseJSON = withObject "MasterCaseResource" parse
     where
-      parse o = BaseProductMasterCaseResource
+      parse o = BaseProductResponseMasterCaseResource
                 <$> o .: "sku"
                 <*> o .: "dimensions"
                 <*> o .: "values"
@@ -4229,52 +4533,102 @@ newtype DimensionsLength = DimensionsLength
 
 type LengthUnit = PieceLengthUnits
 
-data Values = Values
-  { vResourceLocation :: Maybe ResponseResourceLocation
-  , vResource         :: Maybe ValuesResource
+data ValuesResponse = ValuesResponse
+  { vrResourceLocation :: Maybe ResponseResourceLocation
+  , vrResource         :: Maybe ValuesResource
   } deriving (Eq, Show)
 
-instance FromJSON Values where
-  parseJSON = withObject "Values" parse
+instance FromJSON ValuesResponse where
+  parseJSON = withObject "ValuesResponse" parse
     where
-      parse o = Values
+      parse o = ValuesResponse
                 <$> o .:? "resourceLocation"
                 <*> o .:? "resource"
 
 data ValuesResource = ValuesResource
-  { vrCostValueCurrency      :: CostValueCurrency
-  , vrWholesaleValue         :: WholesaleValue
-  , vrCostValue              :: CostValue
+  { vrCostValueCurrency      :: Maybe CostValueCurrency
+  , vrWholesaleValue         :: WholesaleValueResponse
+  , vrCostValue              :: CostValueResponse
   , vrWholesaleValueCurrency :: WholesaleValueCurrency
-  , vrRetailValue            :: RetailValue
+  , vrRetailValue            :: RetailValueResponse
   , vrRetailValueCurrency    :: RetailValueCurrency
   } deriving (Eq, Show)
+
+data Values = Values
+  { vCostValue         :: CostValue
+  , vWholesaleValue    :: WholesaleValue
+  , vRetailValue       :: RetailValue
+  , vCostCurrency      :: CostCurrency
+  , vWholesaleCurrency :: WholesaleCurrency
+  , vRetailCurrency    :: RetailCurrency
+  } deriving (Eq, Show)
+
+instance ToJSON Values where
+  toJSON Values {..} = object ["costValue"         .= vCostValue
+                              ,"wholesaleValue"    .= vWholesaleValue
+                              ,"retailValue"       .= vRetailValue
+                              ,"costCurrency"      .= vCostCurrency
+                              ,"wholesaleCurrency" .= vWholesaleCurrency
+                              ,"retailCurrency"    .= vRetailCurrency]
 
 instance FromJSON ValuesResource where
   parseJSON = withObject "ValuesResource" parse
     where
       parse o = ValuesResource
-                <$> o .: "costValueCurrency"
-                <*> o .: "wholesaleValue"
-                <*> o .: "costValue"
-                <*> o .: "wholesaleValueCurrency"
-                <*> o .: "retailValue"
-                <*> o .: "retailValueCurrency"
+                <$> o .:? "costValueCurrency"
+                <*> o .:  "wholesaleValue"
+                <*> o .:  "costValue"
+                <*> o .:  "wholesaleValueCurrency"
+                <*> o .:  "retailValue"
+                <*> o .:  "retailValueCurrency"
 
-type CostValueCurrency      = Currency
-type WholesaleValueCurrency = Currency
-type RetailValueCurrency    = Currency
+newtype WholesaleValueCurrency = WholesaleValueCurrency
+  { unWholesaleValueCurrency :: Text
+  } deriving (Eq, Show, ToJSON, FromJSON)
 
-newtype CostValue = CostValue
-  { unCostValue :: Text
+newtype WholesaleCurrency = WholesaleCurrency
+  { unWholesaleCurrency :: Text
+  } deriving (Eq, Show, ToJSON)
+
+newtype RetailValueCurrency = RetailValueCurrency
+  { unRetailValueCurrency :: Text
+  } deriving (Eq, Show, ToJSON, FromJSON)
+
+newtype RetailCurrency = RetailCurrency
+  { unRetailCurrency :: Text
+  } deriving (Eq, Show, ToJSON)
+
+newtype CostValueCurrency = CostValueCurrency
+  { unCostValueCurrency :: Text
+  } deriving (Eq, Show, ToJSON, FromJSON)
+
+newtype CostValueResponse = CostValueResponse
+  { unCostValueR :: Text
   } deriving (Eq, Show, FromJSON)
 
-type WholesaleValue = CostValue
-type RetailValue    = CostValue
+newtype CostValue = CostValue
+  { unCostValue :: Integer
+  } deriving (Eq, Show, ToJSON)
+
+newtype WholesaleValue = WholesaleValue
+  { unWholesaleValue :: Integer
+  } deriving (Eq, Show, ToJSON)
+
+newtype WholesaleValueResponse = WholesaleValueResponse
+  { unWholesaleValeuResponse :: Text
+  } deriving (Eq, Show, FromJSON)
+
+newtype RetailValue = RetailValue
+  { unRetailValue :: Integer
+  } deriving (Eq, Show, ToJSON)
+
+newtype RetailValueResponse = RetailValueResponse
+  { unRetailValueResponsee :: Text
+  } deriving (Eq, Show, FromJSON)
 
 newtype IndividualItemsPerCase = IndividualItemsPerCase
   { unIndividualItemsPerCase :: Integer
-  } deriving (Eq, Show, FromJSON)
+  } deriving (Eq, Show, ToJSON, FromJSON)
 
 data MasterCaseFlags = MasterCaseFlags
   { mcfResourceLocation :: Maybe ResponseResourceLocation
@@ -4290,7 +4644,7 @@ instance FromJSON MasterCaseFlags where
 
 newtype MasterCaseFlagsResource = MasterCaseFlagsResource
   { unFlagsResource :: IsPackagedReadyToShip
-  } deriving (Eq, Show, FromJSON)
+  } deriving (Eq, Show, ToJSON, FromJSON)
 
 data IsPackagedReadyToShip = PackagedReadyToShip
   | NotPackagedReadyToShip
@@ -4303,3 +4657,10 @@ instance FromJSON IsPackagedReadyToShip where
       parse 1 = pure PackagedReadyToShip
       parse _ = error "Bad input"
 
+instance ToJSON IsPackagedReadyToShip where
+  toJSON NotPackagedReadyToShip = Number 0
+  toJSON PackagedReadyToShip    = Number 1
+
+newtype CountryOfOrigin = CountryOfOrigin
+  { unCountryOfOrigin :: Text
+  } deriving (Eq, Show, ToJSON, FromJSON)

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -468,7 +468,7 @@ module Ballast.Types
   , MarketingInsertWidth(..)
   , MarketingInsertHeight(..)
   , MarketingInsertWeight(..)
-  , MarketingInsertInclusionRules(..)  
+  , MarketingInsertInclusionRules(..)
   , ShouldNotFold(..)
   , MarketingInsertFlags(..)
   , InsertWhenWorthValue(..)
@@ -3212,7 +3212,7 @@ instance ToJSON VirtualKitContentObject where
   toJSON VirtualKitContentObject {..} = omitNulls ["productId"  .= vkcoProductId
                                                   ,"externalId" .= vkcoExternalId
                                                   ,"quantity"   .= vkcoQuantity]
-  
+
 data Kit = Kit
   { kSku                  :: SKU
   , kExternalId           :: Maybe ExternalId
@@ -3444,7 +3444,7 @@ instance ToJSON KitValues where
 data MarketingInsert = MarketingInsert
   { miSku               :: SKU
   , miExternalId        :: Maybe ExternalId
-  , miClassification    :: Classification  
+  , miClassification    :: Classification
   , miDescription       :: Description
   , miInclusionRuleType :: InclusionRuleType
   , miAlternateNames    :: Maybe MarketingInsertAlternateNames
@@ -3674,7 +3674,7 @@ instance ToJSON BaseProductPallet where
                                             ,"values"                 .= bppValues
                                             ,"dimensions"             .= bppDimensions
                                             ,"flags"                  .= bppFlags]
-                                          
+
 newtype BaseProductPalletFlags = BaseProductPalletFlags
   { bppfIsPackagedReadyToShip :: IsPackagedReadyToShip
   } deriving (Eq, Show, ToJSON)
@@ -3724,7 +3724,7 @@ instance ToJSON BaseProductInnerPack where
 newtype BaseProductInnerPackFlags = BaseProductInnerPackFlags
   { bpipfIsPackagedReadyToShip :: IsPackagedReadyToShip
   } deriving (Eq, Show, ToJSON)
-    
+
 newtype BaseProductAlternateNames = BaseProductAlternateNames
   { bpanAlternateNames :: [BaseProductAlternateName]
   } deriving (Eq, Show, ToJSON)
@@ -4013,7 +4013,7 @@ instance FromJSON GetProductsResponseResourceItem where
       parse o = GetProductsResponseResourceItem
                 <$> o .: "resourceLocation"
                 <*> o .: "resource"
-                
+
 -- | This a wrapper for different classifications of products.
 -- Possible options are: baseProduct, marketingInsert, virtualKit, kit.
 data ProductsWrapper = PwBaseProduct BaseProductResponseResource
@@ -4456,31 +4456,31 @@ instance FromJSON BaseProductResponseResource where
 
 parseBaseProduct :: Object -> Parser BaseProductResponseResource
 parseBaseProduct o = BaseProductResponseResource
-                     <$> o .:  "classification"      
+                     <$> o .:  "classification"
                      <*> o .:? "batteryConfiguration"
-                     <*> o .:? "masterCase"          
-                     <*> o .:  "itemCount"           
-                     <*> o .:  "id"                  
-                     <*> o .:  "sku"                 
-                     <*> o .:? "archivedDate"        
-                     <*> o .:  "enqueuedDimensions"  
-                     <*> o .:  "dimensions"          
-                     <*> o .:? "innerPack"           
-                     <*> o .:? "pallet"              
-                     <*> o .:? "externalId"          
-                     <*> o .:  "alternateNames"      
-                     <*> o .:  "values"              
-                     <*> o .:  "status"              
+                     <*> o .:? "masterCase"
+                     <*> o .:  "itemCount"
+                     <*> o .:  "id"
+                     <*> o .:  "sku"
+                     <*> o .:? "archivedDate"
+                     <*> o .:  "enqueuedDimensions"
+                     <*> o .:  "dimensions"
+                     <*> o .:? "innerPack"
+                     <*> o .:? "pallet"
+                     <*> o .:? "externalId"
+                     <*> o .:  "alternateNames"
+                     <*> o .:  "values"
+                     <*> o .:  "status"
                      <*> o .:? "category"
                      <*> o .:? "vendorId"
                      <*> o .:? "vendorExternalId"
-                     <*> o .:  "description"         
-                     <*> o .:  "flags"               
-                     <*> o .:  "creationDate"        
-                     <*> o .:? "hsCode"              
-                     <*> o .:? "countryOfOrigin"     
+                     <*> o .:  "description"
+                     <*> o .:  "flags"
+                     <*> o .:  "creationDate"
+                     <*> o .:? "hsCode"
+                     <*> o .:? "countryOfOrigin"
                      <*> o .:  "storageConfiguration"
-                     <*> o .:? "technicalData"       
+                     <*> o .:? "technicalData"
 
 data TechnicalData = TechnicalData
   { tdResourceLocation :: Maybe ResponseResourceLocation
@@ -4673,7 +4673,7 @@ instance FromJSON IsPerishable where
 instance ToJSON IsPerishable where
   toJSON NotPerishable = Number 0
   toJSON Perishable    = Number 1
- 
+
 data IsDangerous = Dangerous
   | NotDangerous
   deriving (Eq, Show)
@@ -4996,10 +4996,10 @@ instance FromJSON Dimensions where
 data DimensionsResource = DimensionsResource
   { drWeight     :: DimensionsWeight
   , drWeightUnit :: WeightUnit
-  , drHeight     :: DimensionsHeight  
+  , drHeight     :: DimensionsHeight
   , drHeightUnit :: HeightUnit
   , drWidth      :: DimensionsWidth
-  , drWidthUnit  :: WidthUnit  
+  , drWidthUnit  :: WidthUnit
   , drLength     :: DimensionsLength
   , drLengthUnit :: LengthUnit
   } deriving (Eq, Show)

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -505,6 +505,15 @@ module Ballast.Types
   , KitAlternateName(..)
   , KitValues(..)
   , utcToShipwire
+  , RetireProductsRequest
+  , RetireProductsResponse(..)
+  , ProductsToRetire(..)
+  , Message(..)
+  , MoreInfo(..)
+  , MoreInfoItems(..)
+  , MoreInfoItem(..)
+  , Configuration(..)
+  , Success(..)
   ) where
 
 import           Data.Aeson
@@ -3169,6 +3178,73 @@ data CreateProductsRequest
 type instance ShipwireReturn CreateProductsRequest = CreateProductsResponse
 
 type CreateProductsResponse = GetProductsResponse
+
+-- | POST /api/v3/products/retire
+data RetireProductsRequest
+type instance ShipwireReturn RetireProductsRequest = RetireProductsResponse
+
+newtype ProductsToRetire = ProductsToRetire
+  { rpIds :: [ProductId]
+  } deriving (Eq, Show)
+
+instance ToJSON ProductsToRetire where
+  toJSON ProductsToRetire {..} = object ["ids" .= rpIds]
+
+data RetireProductsResponse = RetireProductsResponse
+  { rprMessage          :: Message
+  , rprMoreInfo         :: Maybe MoreInfo
+  , rprResourceLocation :: Maybe ResponseResourceLocation
+  , rprStatus           :: ResponseStatus
+  } deriving (Eq, Show)
+
+instance FromJSON RetireProductsResponse where
+  parseJSON = withObject "RetireProductsResponse" parse
+    where
+      parse o = RetireProductsResponse
+                <$> o .:  "message"
+                <*> o .:? "moreInfo"
+                <*> o .:? "resourceLocation"
+                <*> o .:  "status"
+
+newtype Message = Message
+  { unMessage :: Text
+  } deriving (Eq, Show, FromJSON)
+
+newtype MoreInfo = MoreInfo
+  { miItems :: [MoreInfoItems]
+  } deriving (Eq, Show, FromJSON)
+
+newtype MoreInfoItems = MoreInfoItems
+  { miiItems :: [MoreInfoItem]
+  } deriving (Eq, Show, FromJSON)
+
+data MoreInfoItem = MoreInfoItem
+  { miiId            :: Id
+  , miiExternalId    :: Maybe ExternalId
+  , miiSku           :: SKU
+  , miiStatus        :: Status
+  , miiConfiguration :: Configuration
+  , miiSuccess       :: Success
+  } deriving (Eq, Show)
+
+instance FromJSON MoreInfoItem where
+  parseJSON = withObject "MoreInfoItem" parse
+    where
+      parse o = MoreInfoItem
+                <$> o .: "id"
+                <*> o .: "externalId"
+                <*> o .: "sku"
+                <*> o .: "status"
+                <*> o .: "configuration"
+                <*> o .: "success"
+
+newtype Configuration = Configuration
+  { unConfiguration :: Text
+  } deriving (Eq, Show, FromJSON)
+
+newtype Success = Success
+  { unSuccess :: Bool
+  } deriving (Eq, Show, FromJSON)
 
 -- | You can create multiple products of different classifications at the same time
 -- by passing them inside a JSON array. To distinguish between different ToJSON instances

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -3204,7 +3204,7 @@ newtype VirtualKitContent = VirtualKitContent
   } deriving (Eq, Show, ToJSON)
 
 data VirtualKitContentObject = VirtualKitContentObject
-  { vkcoProductId  :: ProductId
+  { vkcoProductId  :: Maybe ProductId
   , vkcoExternalId :: Maybe ExternalId
   , vkcoQuantity   :: Quantity
   } deriving (Eq, Show)
@@ -3220,13 +3220,13 @@ data Kit = Kit
   , kClassification       :: Classification
   , kDescription          :: Description
   , kBatteryConfiguration :: BatteryConfiguration
-  , kHsCode               :: HsCode
-  , kCountryOfOrigin      :: CountryOfOrigin
+  , kHsCode               :: Maybe HsCode
+  , kCountryOfOrigin      :: Maybe CountryOfOrigin
   , kValues               :: KitValues
-  , kAlternateNames       :: KitAlternateNames
+  , kAlternateNames       :: Maybe KitAlternateNames
   , kContent              :: KitContent
   , kDimensions           :: KitDimensions
-  , kTechnicalData        :: KitTechnicalData
+  , kTechnicalData        :: Maybe KitTechnicalData
   , kFlags                :: KitFlags
   , kInnerPack            :: KitInnerPack
   , kMasterCase           :: KitMasterCase
@@ -3355,20 +3355,20 @@ newtype KitTechnicalData = KitTechnicalData
 
 data KitTechnicalDataBattery = KitTechnicalDataBattery
   { ktdbType              :: BatteryType
-  , ktdbBatteryWeight     :: BatteryWeight
-  , ktdbNumberOfBatteries :: NumberOfBatteries
-  , ktdbCapacity          :: Capacity
-  , ktdbNumberOfCells     :: NumberOfCells
-  , ktdbCapacityUnit      :: CapacityUnit
+  , ktdbBatteryWeight     :: Maybe BatteryWeight
+  , ktdbNumberOfBatteries :: Maybe NumberOfBatteries
+  , ktdbCapacity          :: Maybe Capacity
+  , ktdbNumberOfCells     :: Maybe NumberOfCells
+  , ktdbCapacityUnit      :: Maybe CapacityUnit
   } deriving (Eq, Show)
 
 instance ToJSON KitTechnicalDataBattery where
-  toJSON KitTechnicalDataBattery {..} = object ["type"              .= ktdbType
-                                               ,"batteryWeight"     .= ktdbBatteryWeight
-                                               ,"numberOfBatteries" .= ktdbNumberOfBatteries
-                                               ,"capacity"          .= ktdbCapacity
-                                               ,"numberOfCells"     .= ktdbNumberOfCells
-                                               ,"capacityUnit"      .= ktdbCapacityUnit]
+  toJSON KitTechnicalDataBattery {..} = omitNulls ["type"              .= ktdbType
+                                                  ,"batteryWeight"     .= ktdbBatteryWeight
+                                                  ,"numberOfBatteries" .= ktdbNumberOfBatteries
+                                                  ,"capacity"          .= ktdbCapacity
+                                                  ,"numberOfCells"     .= ktdbNumberOfCells
+                                                  ,"capacityUnit"      .= ktdbCapacityUnit]
 
 data KitDimensions = KitDimensions
   { kdLength :: KitLength
@@ -3404,7 +3404,7 @@ newtype KitContent = KitContent
   } deriving (Eq, Show, ToJSON)
 
 data KitContentObject = KitContentObject
-  { kcProductId  :: ProductId
+  { kcProductId  :: Maybe ProductId
   , kcExternalId :: Maybe ExternalId
   , kcQuantity   :: Quantity
   } deriving (Eq, Show)
@@ -3429,18 +3429,18 @@ data KitValues = KitValues
   { kvCostValue         :: CostValue
   , kvWholesaleValue    :: WholesaleValue
   , kvRetailValue       :: RetailValue
-  , kvCostCurrency      :: CostCurrency
-  , kvWholesaleCurrency :: WholesaleCurrency
-  , kvRetailCurrency    :: RetailCurrency
+  , kvCostCurrency      :: Maybe CostCurrency
+  , kvWholesaleCurrency :: Maybe WholesaleCurrency
+  , kvRetailCurrency    :: Maybe RetailCurrency
   } deriving (Eq, Show)
 
 instance ToJSON KitValues where
-  toJSON KitValues {..} = object ["costValue"         .= kvCostValue
-                                 ,"wholesaleValue"    .= kvWholesaleValue
-                                 ,"retailValue"       .= kvRetailValue
-                                 ,"costCurrency"      .= kvCostCurrency
-                                 ,"wholesaleCurrency" .=  kvWholesaleCurrency
-                                 ,"retailCurrency"    .= kvRetailCurrency]
+  toJSON KitValues {..} = omitNulls ["costValue"         .= kvCostValue
+                                    ,"wholesaleValue"    .= kvWholesaleValue
+                                    ,"retailValue"       .= kvRetailValue
+                                    ,"costCurrency"      .= kvCostCurrency
+                                    ,"wholesaleCurrency" .= kvWholesaleCurrency
+                                    ,"retailCurrency"    .= kvRetailCurrency]
 
 data MarketingInsert = MarketingInsert
   { miSku               :: SKU
@@ -3448,10 +3448,10 @@ data MarketingInsert = MarketingInsert
   , miClassification    :: Classification  
   , miDescription       :: Description
   , miInclusionRuleType :: InclusionRuleType
-  , miAlternateNames    :: MarketingInsertAlternateNames
+  , miAlternateNames    :: Maybe MarketingInsertAlternateNames
   , miDimensions        :: MarketingInsertDimensions
   , miFlags             :: MarketingInsertFlags
-  , miInclusionRules    :: MarketingInsertInclusionRules
+  , miInclusionRules    :: Maybe MarketingInsertInclusionRules
   , miMasterCase        :: MarketingInsertMasterCase
   } deriving (Eq, Show)
 
@@ -3550,19 +3550,19 @@ data ShouldNotFold = ShouldNotFold
   deriving (Eq, Show)
 
 data MarketingInsertInclusionRules = MarketingInsertInclusionRules
-  { miirInsertAfterDate         :: InsertAfterDate
-  , miirInsertBeforeDate        :: InsertBeforeDate
-  , miirInsertWhenWorthValue    :: InsertWhenWorthValue
-  , miirInsertWhenQuantity      :: InsertWhenQuantity
-  , miirInsertWhenWorthCurrency :: InsertWhenWorthCurrency
+  { miirInsertAfterDate         :: Maybe InsertAfterDate
+  , miirInsertBeforeDate        :: Maybe InsertBeforeDate
+  , miirInsertWhenWorthValue    :: Maybe InsertWhenWorthValue
+  , miirInsertWhenQuantity      :: Maybe InsertWhenQuantity
+  , miirInsertWhenWorthCurrency :: Maybe InsertWhenWorthCurrency
   } deriving (Eq, Show)
 
 instance ToJSON MarketingInsertInclusionRules where
-  toJSON MarketingInsertInclusionRules {..} = object ["insertAfterDate"         .= miirInsertAfterDate
-                                                     ,"insertBeforeDate"        .= miirInsertBeforeDate
-                                                     ,"insertWhenWorthValue"    .= miirInsertWhenWorthValue
-                                                     ,"insertWhenQuantity"      .= miirInsertWhenQuantity
-                                                     ,"insertWhenWorthCurrency" .= miirInsertWhenWorthCurrency]
+  toJSON MarketingInsertInclusionRules {..} = omitNulls ["insertAfterDate"         .= miirInsertAfterDate
+                                                        ,"insertBeforeDate"        .= miirInsertBeforeDate
+                                                        ,"insertWhenWorthValue"    .= miirInsertWhenWorthValue
+                                                        ,"insertWhenQuantity"      .= miirInsertWhenQuantity
+                                                        ,"insertWhenWorthCurrency" .= miirInsertWhenWorthCurrency]
 
 instance ToJSON ShouldNotFold where
   toJSON ShouldNotFold = Number 1
@@ -3626,7 +3626,7 @@ data BaseProduct = BaseProduct
   , bpClassification       :: Classification
   , bpDescription          :: Description
   , bpHsCode               :: Maybe HsCode
-  , bpCountryOfOrigin      :: CountryOfOrigin
+  , bpCountryOfOrigin      :: Maybe CountryOfOrigin
   , bpCategory             :: Category
   , bpBatteryConfiguration :: BatteryConfiguration
   , bpValues               :: Values
@@ -3659,7 +3659,7 @@ instance ToJSON BaseProduct where
 
 data BaseProductPallet = BaseProductPallet
   { bppIndividualItemsPerCase :: IndividualItemsPerCase
-  , bppExternalid             :: ExternalId
+  , bppExternalid             :: Maybe ExternalId
   , bppSku                    :: SKU
   , bppDescription            :: Description
   , bppValues                 :: Values
@@ -3668,13 +3668,13 @@ data BaseProductPallet = BaseProductPallet
   } deriving (Eq, Show)
 
 instance ToJSON BaseProductPallet where
-  toJSON BaseProductPallet {..} = object ["individualItemsPerCase" .= bppIndividualItemsPerCase
-                                         ,"externalId"             .= bppExternalid
-                                         ,"sku"                    .= bppSku
-                                         ,"description"            .= bppDescription
-                                         ,"values"                 .= bppValues
-                                         ,"dimensions"             .= bppDimensions
-                                         ,"flags"                  .= bppFlags]
+  toJSON BaseProductPallet {..} = omitNulls ["individualItemsPerCase" .= bppIndividualItemsPerCase
+                                            ,"externalId"             .= bppExternalid
+                                            ,"sku"                    .= bppSku
+                                            ,"description"            .= bppDescription
+                                            ,"values"                 .= bppValues
+                                            ,"dimensions"             .= bppDimensions
+                                            ,"flags"                  .= bppFlags]
                                           
 newtype BaseProductPalletFlags = BaseProductPalletFlags
   { bppfIsPackagedReadyToShip :: IsPackagedReadyToShip
@@ -3682,7 +3682,7 @@ newtype BaseProductPalletFlags = BaseProductPalletFlags
 
 data BaseProductMasterCase = BaseProductMasterCase
   { bpmcIndividualItemsPerCase :: IndividualItemsPerCase
-  , bpmcExternalId             :: ExternalId
+  , bpmcExternalId             :: Maybe ExternalId
   , bpmcSku                    :: SKU
   , bpmcDescription            :: Description
   , bpmcValues                 :: Values
@@ -3705,7 +3705,7 @@ newtype BaseProductMasterCaseFlags = BaseProductMasterCaseFlags
 
 data BaseProductInnerPack = BaseProductInnerPack
   { bpipIndividualItemsPerCase :: IndividualItemsPerCase
-  , bpipExternalId             :: ExternalId
+  , bpipExternalId             :: Maybe ExternalId
   , bpipSku                    :: SKU
   , bpipDescription            :: Description
   , bpipValues                 :: Values
@@ -3714,13 +3714,13 @@ data BaseProductInnerPack = BaseProductInnerPack
   } deriving (Eq, Show)
 
 instance ToJSON BaseProductInnerPack where
-  toJSON BaseProductInnerPack {..} = object ["individualItemsPerCase" .= bpipIndividualItemsPerCase
-                                            ,"externalId"             .= bpipExternalId
-                                            ,"sku"                    .= bpipSku
-                                            ,"description"            .= bpipDescription
-                                            ,"values"                 .= bpipValues
-                                            ,"dimensions"             .= bpipDimensions
-                                            ,"flags"                  .= bpipFlags]
+  toJSON BaseProductInnerPack {..} = omitNulls ["individualItemsPerCase" .= bpipIndividualItemsPerCase
+                                               ,"externalId"             .= bpipExternalId
+                                               ,"sku"                    .= bpipSku
+                                               ,"description"            .= bpipDescription
+                                               ,"values"                 .= bpipValues
+                                               ,"dimensions"             .= bpipDimensions
+                                               ,"flags"                  .= bpipFlags]
 
 newtype BaseProductInnerPackFlags = BaseProductInnerPackFlags
   { bpipfIsPackagedReadyToShip :: IsPackagedReadyToShip
@@ -3767,21 +3767,21 @@ newtype BaseProductTechnicalData = BaseProductTechnicalData
   } deriving (Eq, Show, ToJSON)
 
 data BaseProductTechnicalDataBattery = BaseProductTechnicalDataBattery
-  { bptdbType              :: BatteryType
-  , bptdbBatteryWeight     :: BatteryWeight
-  , bptdbNumberOfBatteries :: NumberOfBatteries
-  , bptdbCapacity          :: Capacity
-  , bptdbNumberOfCells     :: NumberOfCells
-  , bptdbCapacityUnit      :: CapacityUnit
+  { bptdbType              :: Maybe BatteryType
+  , bptdbBatteryWeight     :: Maybe BatteryWeight
+  , bptdbNumberOfBatteries :: Maybe NumberOfBatteries
+  , bptdbCapacity          :: Maybe Capacity
+  , bptdbNumberOfCells     :: Maybe NumberOfCells
+  , bptdbCapacityUnit      :: Maybe CapacityUnit
   } deriving (Eq, Show)
 
 instance ToJSON BaseProductTechnicalDataBattery where
-  toJSON BaseProductTechnicalDataBattery {..} = object ["type"              .= bptdbType
-                                                       ,"batteryWeight"     .= bptdbBatteryWeight
-                                                       ,"numberOfBatteries" .= bptdbNumberOfBatteries
-                                                       ,"capacity"          .= bptdbCapacity
-                                                       ,"numberOfCells"     .= bptdbNumberOfCells
-                                                       ,"capacityUnit"      .= bptdbCapacityUnit]
+  toJSON BaseProductTechnicalDataBattery {..} = omitNulls ["type"              .= bptdbType
+                                                          ,"batteryWeight"     .= bptdbBatteryWeight
+                                                          ,"numberOfBatteries" .= bptdbNumberOfBatteries
+                                                          ,"capacity"          .= bptdbCapacity
+                                                          ,"numberOfCells"     .= bptdbNumberOfCells
+                                                          ,"capacityUnit"      .= bptdbCapacityUnit]
 
 data BaseProductDimensions = BaseProductDimensions
   { bpdLength :: BaseProductLength
@@ -5063,18 +5063,18 @@ data Values = Values
   { vCostValue         :: CostValue
   , vWholesaleValue    :: WholesaleValue
   , vRetailValue       :: RetailValue
-  , vCostCurrency      :: CostCurrency
-  , vWholesaleCurrency :: WholesaleCurrency
-  , vRetailCurrency    :: RetailCurrency
+  , vCostCurrency      :: Maybe CostCurrency
+  , vWholesaleCurrency :: Maybe WholesaleCurrency
+  , vRetailCurrency    :: Maybe RetailCurrency
   } deriving (Eq, Show)
 
 instance ToJSON Values where
-  toJSON Values {..} = object ["costValue"         .= vCostValue
-                              ,"wholesaleValue"    .= vWholesaleValue
-                              ,"retailValue"       .= vRetailValue
-                              ,"costCurrency"      .= vCostCurrency
-                              ,"wholesaleCurrency" .= vWholesaleCurrency
-                              ,"retailCurrency"    .= vRetailCurrency]
+  toJSON Values {..} = omitNulls ["costValue"         .= vCostValue
+                                 ,"wholesaleValue"    .= vWholesaleValue
+                                 ,"retailValue"       .= vRetailValue
+                                 ,"costCurrency"      .= vCostCurrency
+                                 ,"wholesaleCurrency" .= vWholesaleCurrency
+                                 ,"retailCurrency"    .= vRetailCurrency]
 
 instance FromJSON ValuesResource where
   parseJSON = withObject "ValuesResource" parse

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -519,6 +519,8 @@ module Ballast.Types
   , GetProductRequest
   , GetProductResponse(..)
   , GetProductResponseResource(..)
+  , ModifyProductRequest
+  , ModifyProductResponse
   ) where
 
 import           Control.Applicative ((<|>))
@@ -563,9 +565,9 @@ mkShipwireRequest m e p = ShipwireRequest m e p
 
 type family ShipwireReturn a :: *
 
----------------------------------------------------------------------
--- Rate Endpoint -- https://www.shipwire.com/w/developers/rate/
----------------------------------------------------------------------
+---------------------------------------------------------------
+-- Rate Endpoint https://www.shipwire.com/w/developers/rate/ --
+---------------------------------------------------------------
 
 data RateRequest
 type instance ShipwireReturn RateRequest = RateResponse
@@ -1291,9 +1293,9 @@ instance FromJSON PieceContent where
 type Reply = Network.HTTP.Client.Response BSL.ByteString
 type Method = NHTM.Method
 
----------------------------------------------------------------------
--- Stock Endpoint -- https://www.shipwire.com/w/developers/stock/
----------------------------------------------------------------------
+-----------------------------------------------------------------
+-- Stock Endpoint https://www.shipwire.com/w/developers/stock/ --
+-----------------------------------------------------------------
 
 data StockRequest
 type instance ShipwireReturn StockRequest = StockResponse
@@ -1806,9 +1808,9 @@ filterQuery :: [Params (BS8.ByteString, BS8.ByteString) c] -> [(BS8.ByteString, 
 filterQuery [] = []
 filterQuery xs = [b | Query b <- xs]
 
--------------------------------------------------------------------------
--- Receiving Endpoint -- https://www.shipwire.com/w/developers/receiving
--------------------------------------------------------------------------
+---------------------------------------------------------------------------
+-- Receiving Endpoint -- https://www.shipwire.com/w/developers/receiving --
+---------------------------------------------------------------------------
 
 -- | GET /api/v3/receivings
 data GetReceivingsRequest
@@ -3167,9 +3169,9 @@ instance FromJSON GetReceivingLabelsResponse where
                 <*> o .:? "warnings"
                 <*> o .:? "errors"
 
--------------------------------------------------------------------------
--- Product Endpoint -- https://www.shipwire.com/w/developers/product
--------------------------------------------------------------------------
+-----------------------------------------------------------------------
+-- Product Endpoint -- https://www.shipwire.com/w/developers/product --
+-----------------------------------------------------------------------
 
 -- | GET /api/v3/products
 data GetProductsRequest
@@ -3195,6 +3197,12 @@ type CreateProductsResponse = GetProductsResponse
 -- | PUT /api/v3/products
 data ModifyProductsRequest
 type instance ShipwireReturn ModifyProductsRequest = ModifyProductsResponse
+
+-- | PUT /api/v3/products/{id}
+data ModifyProductRequest
+type instance ShipwireReturn ModifyProductRequest = ModifyProductResponse
+
+type ModifyProductResponse = ModifyProductsResponse
 
 -- | GET /api/v3/products/{id}
 data GetProductRequest

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -4322,8 +4322,8 @@ instance FromJSON InclusionRules where
 
 data InclusionRulesResource = InclusionRulesResource
   { irrProductId                    :: ProductId
-  , irrInsertAfterDate              :: InsertAfterDate
-  , irrInsertBeforeDate             :: InsertBeforeDate
+  , irrInsertAfterDate              :: Maybe InsertAfterDate
+  , irrInsertBeforeDate             :: Maybe InsertBeforeDate
   , irrInsertWhenWorthValue         :: InsertWhenWorthValueResponse
   , irrInsertWhenWorthValueCurrency :: InsertWhenWorthValueCurrency
   , irrInsertWhenQuantity           :: InsertWhenQuantity
@@ -4335,8 +4335,8 @@ instance FromJSON InclusionRulesResource where
     where
       parse o = InclusionRulesResource
                 <$> o .:  "productId"
-                <*> o .:  "insertAfterDate"
-                <*> o .:  "insertBeforeDate"
+                <*> o .:? "insertAfterDate"
+                <*> o .:? "insertBeforeDate"
                 <*> o .:  "insertWhenWorthValue"
                 <*> o .:  "insertWhenWorthValueCurrency"
                 <*> o .:  "insertWhenQuantity"
@@ -4402,7 +4402,7 @@ instance FromJSON MarketingInsertFlagsResponse where
 
 data MarketingInsertFlagsResponseResource = MarketingInsertFlagsResponseResource
   { mifrIsPackagedReadyToShip :: IsPackagedReadyToShip
-  , mifrHasMasterCase         :: HasMasterCase
+  , mifrHasMasterCase         :: Maybe HasMasterCase
   , mifrIsArchivable          :: IsArchivable
   , mifrIsDeletable           :: IsDeletable
   , mifrHasEditRestrictions   :: HasEditRestrictions
@@ -4412,11 +4412,11 @@ instance FromJSON MarketingInsertFlagsResponseResource where
   parseJSON = withObject "MarketingInsertFlagsResponseResource" parse
     where
       parse o = MarketingInsertFlagsResponseResource
-                <$> o .: "isPackagedReadyToShip"
-                <*> o .: "hasMasterCase"
-                <*> o .: "isArchivable"
-                <*> o .: "isDeletable"
-                <*> o .: "hasEditRestrictions"
+                <$> o .:  "isPackagedReadyToShip"
+                <*> o .:? "hasMasterCase"
+                <*> o .:  "isArchivable"
+                <*> o .:  "isDeletable"
+                <*> o .:  "hasEditRestrictions"
 
 data BaseProductResponseResource = BaseProductResponseResource
   { bprClassification       :: Classification
@@ -4496,12 +4496,12 @@ instance FromJSON TechnicalData where
 
 data TechnicalDataResource = TechnicalDataResource
   { tdrCapacityUnit      :: Maybe CapacityUnit
-  , tdrCapacity          :: CapacityResponse
-  , tdrBatteryWeight     :: BatteryWeightResponse
-  , tdrNumberOfCells     :: NumberOfCells
-  , tdrType              :: BatteryType
-  , tdrNumberOfBatteries :: NumberOfBatteries
-  , tdrProductId         :: ProductId
+  , tdrCapacity          :: Maybe CapacityResponse
+  , tdrBatteryWeight     :: Maybe BatteryWeightResponse
+  , tdrNumberOfCells     :: Maybe NumberOfCells
+  , tdrType              :: Maybe BatteryType
+  , tdrNumberOfBatteries :: Maybe NumberOfBatteries
+  , tdrProductId         :: Maybe ProductId
   } deriving (Eq, Show)
 
 instance FromJSON TechnicalDataResource where
@@ -4509,12 +4509,12 @@ instance FromJSON TechnicalDataResource where
     where
       parse o = TechnicalDataResource
                 <$> o .:? "capacityUnit"
-                <*> o .:  "capacity"
-                <*> o .:  "batteryWeight"
-                <*> o .:  "numberOfCells"
-                <*> o .:  "type"
-                <*> o .:  "numberOfBatteries"
-                <*> o .:  "productId"
+                <*> o .:? "capacity"
+                <*> o .:? "batteryWeight"
+                <*> o .:? "numberOfCells"
+                <*> o .:? "type"
+                <*> o .:? "numberOfBatteries"
+                <*> o .:? "productId"
 
 newtype NumberOfBatteries = NumberOfBatteries
   { unNumberOfBatteries :: Integer
@@ -4587,16 +4587,16 @@ instance FromJSON Flags where
 data FlagsResource = FlagsResource
   { frIsMedia               :: IsMedia
   , frIsDeletable           :: IsDeletable
-  , frHasPallet             :: HasPallet
+  , frHasPallet             :: Maybe HasPallet
   , frIsPackagedReadyToShip :: IsPackagedReadyToShip
-  , frHasMasterCase         :: HasMasterCase
+  , frHasMasterCase         :: Maybe HasMasterCase
   , frIsFragile             :: IsFragile
   , frIsArchivable          :: IsArchivable
   , frIsLiquid              :: IsLiquid
-  , frIsDangerous           :: IsDangerous
+  , frIsDangerous           :: Maybe IsDangerous
   , frIsPerishable          :: IsPerishable
   , frHasEditRestrictions   :: HasEditRestrictions
-  , frHasInnerPack          :: HasInnerPack
+  , frHasInnerPack          :: Maybe HasInnerPack
   , frIsAdult               :: IsAdult
   } deriving (Eq, Show)
 
@@ -4604,19 +4604,19 @@ instance FromJSON FlagsResource where
   parseJSON = withObject "FlagsResource" parse
     where
       parse o = FlagsResource
-                <$> o .: "isMedia"
-                <*> o .: "isDeletable"
-                <*> o .: "hasPallet"
-                <*> o .: "isPackagedReadyToShip"
-                <*> o .: "hasMasterCase"
-                <*> o .: "isFragile"
-                <*> o .: "isArchivable"
-                <*> o .: "isLiquid"
-                <*> o .: "isDangerous"
-                <*> o .: "isPerishable"
-                <*> o .: "hasEditRestrictions"
-                <*> o .: "hasInnerPack"
-                <*> o .: "isAdult"
+                <$> o .:  "isMedia"
+                <*> o .:  "isDeletable"
+                <*> o .:? "hasPallet"
+                <*> o .:  "isPackagedReadyToShip"
+                <*> o .:? "hasMasterCase"
+                <*> o .:  "isFragile"
+                <*> o .:  "isArchivable"
+                <*> o .:  "isLiquid"
+                <*> o .:? "isDangerous"
+                <*> o .:  "isPerishable"
+                <*> o .:  "hasEditRestrictions"
+                <*> o .:? "hasInnerPack"
+                <*> o .:  "isAdult"
 
 data IsAdult = Adult
   | NotAdult
@@ -4958,28 +4958,28 @@ instance FromJSON BaseProductResponseMasterCase where
                 <*> o .:? "resource"
 
 data BaseProductResponseMasterCaseResource = BaseProductResponseMasterCaseResource
-  { mcrSku                    :: SKU
-  , mcrDimensions             :: Dimensions
-  , mcrValues                 :: ValuesResource
-  , mcrExternalId             :: ExternalId
-  , mcrIndividualItemsPerCase :: IndividualItemsPerCase
-  , mcrFlags                  :: MasterCaseFlags
-  , mcrProductId              :: ProductId
-  , mcrDescription            :: Description
+  { mcrSku                    :: Maybe SKU
+  , mcrDimensions             :: Maybe Dimensions
+  , mcrValues                 :: Maybe ValuesResource
+  , mcrExternalId             :: Maybe ExternalId
+  , mcrIndividualItemsPerCase :: Maybe IndividualItemsPerCase
+  , mcrFlags                  :: Maybe MasterCaseFlags
+  , mcrProductId              :: Maybe ProductId
+  , mcrDescription            :: Maybe Description
   } deriving (Eq, Show)
 
 instance FromJSON BaseProductResponseMasterCaseResource where
   parseJSON = withObject "MasterCaseResource" parse
     where
       parse o = BaseProductResponseMasterCaseResource
-                <$> o .: "sku"
-                <*> o .: "dimensions"
-                <*> o .: "values"
-                <*> o .: "externalId"
-                <*> o .: "individualItemsPerCase"
-                <*> o .: "flags"
-                <*> o .: "productId"
-                <*> o .: "description"
+                <$> o .:? "sku"
+                <*> o .:? "dimensions"
+                <*> o .:? "values"
+                <*> o .:? "externalId"
+                <*> o .:? "individualItemsPerCase"
+                <*> o .:? "flags"
+                <*> o .:? "productId"
+                <*> o .:? "description"
 
 data Dimensions = Dimensions
   { dResourceLocation :: Maybe ResponseResourceLocation

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -5,7 +5,8 @@ module Main where
 
 import           Ballast.Client
 import           Ballast.Types
-import qualified Data.Text                       as T
+import qualified Data.Text as T
+import           Data.Time.Clock (UTCTime)
 import           Test.Hspec
 import           Test.Hspec.Expectations.Contrib (isRight)
 -- isLeft,
@@ -34,7 +35,7 @@ exampleCreateReceiving =
   CreateReceiving
     Nothing
     Nothing
-    (Just $ ExpectedDateText "2016-11-08T00:00:00-07:00")
+    (Just $ ExpectedDate $ (read "2016-11-19 18:28:52 UTC" :: UTCTime))
     (ReceivingOptions Nothing Nothing $ Just $ WarehouseRegion "TEST 1")
     (ReceivingArrangement
        ArrangementTypeNone
@@ -62,7 +63,7 @@ exampleBadCreateReceiving =
   CreateReceiving
     Nothing
     Nothing
-    (Just $ ExpectedDateText "2016-11-27T00:00:00-07:00")
+    (Just $ ExpectedDate $ (read "2016-11-19 18:28:52 UTC" :: UTCTime))
     (ReceivingOptions Nothing Nothing $ Just $ WarehouseRegion "TEST 1")
     (ReceivingArrangement
        ArrangementTypeNone
@@ -90,7 +91,7 @@ exampleModifiedReceiving =
   CreateReceiving
     Nothing
     Nothing
-    (Just $ ExpectedDateText "2016-11-27T00:00:00-07:00")
+    (Just $ ExpectedDate $ (read "2016-11-19 18:28:52 UTC" :: UTCTime))
     (ReceivingOptions Nothing Nothing $ Just $ WarehouseRegion "TEST 1")
     (ReceivingArrangement
        ArrangementTypeNone
@@ -267,8 +268,8 @@ exampleCreateProduct productId =
                             ShouldNotFold
                           )
                           (Just $ MarketingInsertInclusionRules
-                            (Just $ InsertAfterDate "3016-02-15T13:04:26-05:00")
-                            (Just $ InsertBeforeDate "3016-02-15T13:04:26-05:00")
+                            (Just $ InsertAfterDate $ (read "3011-11-19 18:28:52 UTC" :: UTCTime))
+                            (Just $ InsertBeforeDate $ (read "3011-11-19 18:28:52 UTC" :: UTCTime))
                             (Just $ InsertWhenWorthValue 5)
                             (Just $ InsertWhenQuantity 5)
                             (Just $ InsertWhenWorthCurrency "USD")
@@ -525,6 +526,7 @@ createProductHelper conf cp = do
 unwrapBaseProduct :: ProductsWrapper -> BaseProductResponseResource
 unwrapBaseProduct (PwBaseProduct x) = x
 unwrapBaseProduct _ = error "Bad input"
+
 main :: IO ()
 main = do
   config <- sandboxEnvConfig
@@ -550,6 +552,7 @@ main = do
         result <- shipwire config $ getReceivings -&- (ExpandReceivingsParam [ExpandAll])
                                                   -&- (ReceivingStatusParams [StatusCanceled])
                                                   -&- (WarehouseIdParam ["TEST 1"])
+                                                  -&- (UpdatedAfter $ (read "2017-11-19 18:28:52 UTC" :: UTCTime))
         result `shouldSatisfy` isRight
 
     describe "create a new receiving" $ do

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -113,8 +113,131 @@ exampleModifiedReceiving =
        (Phone "12346"))
     Nothing
 
-exampleCreateProduct :: [CreateProductsWrapper]
-exampleCreateProduct = [CpwMarketingInsert $ MarketingInsert
+-- | Takes a product id as an integer and inserts it in the right spot.
+exampleCreateProduct :: Integer -> [CreateProductsWrapper]
+exampleCreateProduct productId = [CpwKit $ Kit
+                          (SKU "HspecTestKit")
+                          Nothing
+                          (KitClassification)
+                          (Description "This is a kit test")
+                          (BatteryConfiguration "HASLOOSEBATTERY")
+                          (HsCode "010612")
+                          (CountryOfOrigin "US")
+                          (KitValues
+                            (CostValue 1)
+                            (WholesaleValue 2)
+                            (RetailValue 4)
+                            (CostCurrency "USD")
+                            (WholesaleCurrency "USD")
+                            (RetailCurrency "USD")
+                          )
+                          (KitAlternateNames [KitAlternateName (Name "HspecTestAlt")])
+                          -- KitContentObject needs to include ids of other products
+                          -- included in this kit. We use a helper function to create a
+                          -- product and get back that product's id.
+                          (KitContent
+                            [KitContentObject
+                              (ProductId productId)
+                              Nothing
+                              (Quantity 5)
+                            ]
+                          )
+                          (KitDimensions
+                            (KitLength 2)
+                            (KitWidth 2)
+                            (KitHeight 2)
+                            (KitWeight 2)
+                          )
+                          (KitTechnicalData
+                            (KitTechnicalDataBattery
+                              (BatteryType "ALKALINE")
+                              (BatteryWeight 3)
+                              (NumberOfBatteries 5)
+                              (Capacity 6)
+                              (NumberOfCells 7)
+                              (CapacityUnit "WATTHOUR")
+                            )
+                          )
+                          (KitFlags
+                            NotPackagedReadyToShip
+                            NotFragile
+                            NotDangerous
+                            NotPerishable
+                            NotMedia
+                            NotAdult
+                            Liquid
+                            HasBattery
+                            HasInnerPack
+                            HasMasterCase
+                            HasPallet
+                          )
+                          (KitInnerPack
+                           (IndividualItemsPerCase 2)
+                           (SKU "KitInnerPack")
+                           (Description "This is a test for kit inner pack")
+                           (KitValues
+                             (CostValue 1)
+                             (WholesaleValue 2)
+                             (RetailValue 4)
+                             (CostCurrency "USD")
+                             (WholesaleCurrency "USD")
+                             (RetailCurrency "USD")
+                           )
+                           (KitDimensions
+                             (KitLength 2)
+                             (KitWidth 2)
+                             (KitHeight 2)
+                             (KitWeight 2)
+                           )
+                           (KitInnerPackFlags
+                             NotPackagedReadyToShip
+                           )
+                          )
+                          (KitMasterCase
+                            (IndividualItemsPerCase 10)
+                            (SKU "KitMasterCase")
+                            (Description "This is a test for kit master case")
+                            (KitValues
+                              (CostValue 1)
+                              (WholesaleValue 2)
+                              (RetailValue 4)
+                              (CostCurrency "USD")
+                              (WholesaleCurrency "USD")
+                              (RetailCurrency "USD")
+                            )
+                            (KitDimensions
+                              (KitLength 4)
+                              (KitWidth 4)
+                              (KitHeight 4)
+                              (KitWeight 4)
+                            )
+                            (KitMasterCaseFlags
+                              NotPackagedReadyToShip
+                            )
+                          )
+                          (KitPallet
+                            (IndividualItemsPerCase 1000)
+                            (SKU "KitPallet")
+                            (Description "A pallet for hspec kit")
+                            (KitValues
+                              (CostValue 1)
+                              (WholesaleValue 2)
+                              (RetailValue 4)
+                              (CostCurrency "USD")
+                              (WholesaleCurrency "USD")
+                              (RetailCurrency "USD")
+                            )
+                            (KitDimensions
+                              (KitLength 8)
+                              (KitWidth 8)
+                              (KitHeight 8)
+                              (KitWeight 8)
+                            )
+                            (KitPalletFlags
+                              NotPackagedReadyToShip
+                            )
+                          ),
+                        CpwMarketingInsert $ MarketingInsert
                           (SKU "HspecTestInsert2")
                           Nothing
                           (MarketingInsertClassification)
@@ -174,7 +297,7 @@ exampleCreateProduct = [CpwMarketingInsert $ MarketingInsert
                             (BaseProductWeight 10)
                           )
                           (BaseProductTechnicalData 
-                            (BaseProductTechnicalDataResource 
+                            (BaseProductTechnicalDataBattery 
                                 (BatteryType "ALKALINE")
                                 (BatteryWeight 3)
                                 (NumberOfBatteries 5)
@@ -264,6 +387,106 @@ exampleCreateProduct = [CpwMarketingInsert $ MarketingInsert
                           )
                         ]
 
+exampleCreateBaseProduct :: [CreateProductsWrapper]
+exampleCreateBaseProduct =
+  [ CpwBaseProduct $
+    BaseProduct
+      (SKU "HspecTest3")
+      Nothing
+      (BaseProductClassification)
+      (Description "Hspec test product3")
+      (Just $ HsCode "010612")
+      (CountryOfOrigin "US")
+      (Category "TOYS_SPORTS_HOBBIES")
+      (BatteryConfiguration "ISBATTERY")
+      (Values
+         (CostValue 1)
+         (WholesaleValue 2)
+         (RetailValue 4)
+         (CostCurrency "USD")
+         (WholesaleCurrency "USD")
+         (RetailCurrency "USD"))
+      (BaseProductAlternateNames [BaseProductAlternateName (Name "HspecAlt3")])
+      (BaseProductDimensions
+         (BaseProductLength 10)
+         (BaseProductWidth 10)
+         (BaseProductHeight 10)
+         (BaseProductWeight 10))
+      (BaseProductTechnicalData
+         (BaseProductTechnicalDataBattery
+            (BatteryType "ALKALINE")
+            (BatteryWeight 3)
+            (NumberOfBatteries 5)
+            (Capacity 6)
+            (NumberOfCells 7)
+            (CapacityUnit "WATTHOUR")))
+      (BaseProductFlags
+         PackagedReadyToShip
+         Fragile
+         NotDangerous
+         NotPerishable
+         NotMedia
+         NotAdult
+         NotLiquid
+         HasInnerPack
+         HasMasterCase
+         HasPallet)
+      (BaseProductInnerPack
+         (IndividualItemsPerCase 2)
+         (ExternalId "narp55")
+         (SKU "singleInner3")
+         (Description "InnerDesc3")
+         (Values
+            (CostValue 1)
+            (WholesaleValue 2)
+            (RetailValue 4)
+            (CostCurrency "USD")
+            (WholesaleCurrency "USD")
+            (RetailCurrency "USD"))
+         (BaseProductDimensions
+            (BaseProductLength 20)
+            (BaseProductWidth 20)
+            (BaseProductHeight 20)
+            (BaseProductWeight 20))
+         (BaseProductInnerPackFlags NotPackagedReadyToShip))
+      (BaseProductMasterCase
+         (IndividualItemsPerCase 10)
+         (ExternalId "narp66")
+         (SKU "singleMaster4")
+         (Description "masterdesc4")
+         (Values
+            (CostValue 1)
+            (WholesaleValue 2)
+            (RetailValue 4)
+            (CostCurrency "USD")
+            (WholesaleCurrency "USD")
+            (RetailCurrency "USD"))
+         (BaseProductDimensions
+            (BaseProductLength 30)
+            (BaseProductWidth 30)
+            (BaseProductHeight 30)
+            (BaseProductWeight 30))
+         (BaseProductMasterCaseFlags PackagedReadyToShip))
+      (BaseProductPallet
+         (IndividualItemsPerCase 1000)
+         (ExternalId "narp77")
+         (SKU "singlePallet3")
+         (Description "palletdesc3")
+         (Values
+            (CostValue 1)
+            (WholesaleValue 2)
+            (RetailValue 4)
+            (CostCurrency "USD")
+            (WholesaleCurrency "USD")
+            (RetailCurrency "USD"))
+         (BaseProductDimensions
+            (BaseProductLength 40)
+            (BaseProductWidth 40)
+            (BaseProductHeight 40)
+            (BaseProductWeight 40))
+         (BaseProductPalletFlags NotPackagedReadyToShip))
+  ]
+  
 createReceivingHelper :: ShipwireConfig -> CreateReceiving -> IO (Either ShipwireError (ShipwireReturn CreateReceivingRequest), ReceivingId)
 createReceivingHelper conf cr = do
   receiving <- shipwire conf $ createReceiving cr
@@ -275,9 +498,24 @@ createReceivingHelper conf cr = do
   let receivingId = T.pack $ show $ unId rirId
   return (receiving, ReceivingId receivingId)
 
+createProductHelper :: ShipwireConfig -> [CreateProductsWrapper] -> IO (Either ShipwireError (ShipwireReturn CreateProductsRequest), Integer)
+createProductHelper conf cp = do
+  baseProduct <- shipwire conf $ createProduct cp
+  let Right GetProductsResponse {..} = baseProduct
+  let GetProductsResponseResource {..} = gprResource
+  let GetProductsResponseResourceItems {..} = gprrItems
+  let GetProductsResponseResourceItem {..} = last gprriItems
+  let pwBaseProduct@(PwBaseProduct x) = gprriResource
+  let productId = unId $ bprId $ unwrapBaseProduct pwBaseProduct
+  return (baseProduct, productId)
+
+unwrapBaseProduct :: ProductsWrapper -> BaseProductResponseResource
+unwrapBaseProduct (PwBaseProduct x) = x
+unwrapBaseProduct _ = error "Bad input"
 main :: IO ()
 main = do
   config <- sandboxEnvConfig
+  (_, productId) <- createProductHelper config exampleCreateBaseProduct
   (receiving, receivingId) <- createReceivingHelper config exampleCreateReceiving
   hspec $ do
     describe "get rates" $ do
@@ -291,7 +529,7 @@ main = do
 
     describe "get stock info" $ do
       it "gets stock info with optional args" $ do
-        result <- shipwire config $ getStockInfo -&- (SKU "HspecTest")
+        result <- shipwire config $ getStockInfo -&- (SKU "HspecTest3")
         result `shouldSatisfy` isRight
 
     describe "get receivings" $ do
@@ -415,7 +653,7 @@ main = do
 
     describe "create a product" $ do
       it "creates a product" $ do
-        result <- shipwire config $ createProduct exampleCreateProduct
+        result <- shipwire config $ createProduct (exampleCreateProduct productId)
         result `shouldSatisfy` isRight
         let Right GetProductsResponse {..} = result
         gprWarnings `shouldBe` Nothing

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -115,7 +115,20 @@ exampleModifiedReceiving =
 
 -- | Takes a product id as an integer and inserts it in the right spot.
 exampleCreateProduct :: Integer -> [CreateProductsWrapper]
-exampleCreateProduct productId = [CpwKit $ Kit
+exampleCreateProduct productId =
+                       [CpwVirtualKit $ VirtualKit
+                          (SKU "HspecTestVKit")
+                          (VirtualKitClassification)
+                          (Description "This is a virtual kit test")
+                          (VirtualKitContent
+                            [(VirtualKitContentObject
+                              (ProductId productId)
+                              Nothing
+                              (Quantity 5)
+                            )
+                            ]
+                          ),
+                        CpwKit $ Kit
                           (SKU "HspecTestKit")
                           Nothing
                           (KitClassification)
@@ -652,7 +665,7 @@ main = do
         gprErrors `shouldBe` Nothing
 
     describe "create a product" $ do
-      it "creates a product" $ do
+      it "creates all possible product classifications" $ do
         result <- shipwire config $ createProduct (exampleCreateProduct productId)
         result `shouldSatisfy` isRight
         let Right GetProductsResponse {..} = result

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -114,11 +114,46 @@ exampleModifiedReceiving =
     Nothing
 
 exampleCreateProduct :: [CreateProductsWrapper]
-exampleCreateProduct = [CpwBaseProduct $ BaseProduct
-                          (SKU "HspecTest")
+exampleCreateProduct = [CpwMarketingInsert $ MarketingInsert
+                          (SKU "HspecTestInsert2")
+                          Nothing
+                          (MarketingInsertClassification)
+                          (Description "Hspec test marketing insert2")
+                          (InclusionRuleType "CUSTOM")
+                          (MarketingInsertAlternateNames [MarketingInsertAlternateName (Name "HspecMI22")])
+                          (MarketingInsertDimensions
+                            (MarketingInsertLength 0.1)
+                            (MarketingInsertWidth 0.1)
+                            (MarketingInsertHeight 0.1)
+                            (MarketingInsertWeight 0.2)
+                          )
+                          (MarketingInsertFlags
+                            ShouldNotFold
+                          )
+                          (MarketingInsertInclusionRules
+                            (InsertAfterDate "3016-02-15T13:04:26-05:00")
+                            (InsertBeforeDate "3016-02-15T13:04:26-05:00")
+                            (InsertWhenWorthValue 5)
+                            (InsertWhenQuantity 5)
+                            (InsertWhenWorthCurrency "USD")
+                          )
+                          (MarketingInsertMasterCase
+                            (IndividualItemsPerCase 10)
+                            (SKU "HspecTestMIMCSKU")
+                            Nothing
+                            (Description "Hspec test marketing insert master case2")
+                            (MarketingInsertMasterCaseDimensions
+                              (MarketingInsertMasterCaseDimensionsLength 8)
+                              (MarketingInsertMasterCaseDimensionsWidth 8)
+                              (MarketingInsertMasterCaseDimensionsHeight 8)
+                              (MarketingInsertMasterCaseDimensionsWeight 8)
+                            )
+                          ),
+                        CpwBaseProduct $ BaseProduct
+                          (SKU "HspecTest2")
                           Nothing
                           (BaseProductClassification)
-                          (Description "Hspec test product")
+                          (Description "Hspec test product2")
                           (Just $ HsCode "010612")
                           (CountryOfOrigin "US")
                           (Category "TOYS_SPORTS_HOBBIES")
@@ -131,7 +166,7 @@ exampleCreateProduct = [CpwBaseProduct $ BaseProduct
                             (WholesaleCurrency "USD")
                             (RetailCurrency "USD")
                           )
-                          (BaseProductAlternateNames [BaseProductAlternateName (Name "HspecAlt")])
+                          (BaseProductAlternateNames [BaseProductAlternateName (Name "HspecAlt2")])
                           (BaseProductDimensions 
                             (BaseProductLength 10)
                             (BaseProductWidth 10)
@@ -162,9 +197,9 @@ exampleCreateProduct = [CpwBaseProduct $ BaseProduct
                           )
                           (BaseProductInnerPack 
                             (IndividualItemsPerCase 2)
-                            (ExternalId "narp22")
-                            (SKU "singleInner2")
-                            (Description "InnerDec")
+                            (ExternalId "narp222")
+                            (SKU "singleInner22")
+                            (Description "InnerDec2")
                             (Values 
                                 (CostValue 1)
                                 (WholesaleValue 2)
@@ -185,9 +220,9 @@ exampleCreateProduct = [CpwBaseProduct $ BaseProduct
                           )
                           (BaseProductMasterCase 
                             (IndividualItemsPerCase 10)
-                            (ExternalId "narp3")
-                            (SKU "singleMaster2")
-                            (Description "masterdesc")
+                            (ExternalId "narp33")
+                            (SKU "singleMaster23")
+                            (Description "masterdesc3")
                             (Values
                                 (CostValue 1)
                                 (WholesaleValue 2)
@@ -206,9 +241,9 @@ exampleCreateProduct = [CpwBaseProduct $ BaseProduct
                           )
                           (BaseProductPallet 
                             (IndividualItemsPerCase 1000)
-                            (ExternalId "narp4")
-                            (SKU "singlePallet2")
-                            (Description "palletdesc")
+                            (ExternalId "narp42")
+                            (SKU "singlePallet22")
+                            (Description "palletdesc2")
                             (Values 
                                 (CostValue 1)
                                 (WholesaleValue 2)
@@ -378,10 +413,10 @@ main = do
         gprWarnings `shouldBe` Nothing
         gprErrors `shouldBe` Nothing
 
-    -- describe "create a product" $ do
-    --   it "creates a product" $ do
-    --     result <- shipwire config $ createProduct exampleCreateProduct
-    --     result `shouldSatisfy` isRight
-    --     let Right GetProductsResponse {..} = result
-    --     gprWarnings `shouldBe` Nothing
-    --     gprErrors `shouldBe` Nothing
+    describe "create a product" $ do
+      it "creates a product" $ do
+        result <- shipwire config $ createProduct exampleCreateProduct
+        result `shouldSatisfy` isRight
+        let Right GetProductsResponse {..} = result
+        gprWarnings `shouldBe` Nothing
+        gprErrors `shouldBe` Nothing

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -5,7 +5,6 @@ module Main where
 
 import           Ballast.Client
 import           Ballast.Types
-import           Data.Either.Unwrap (fromRight)
 import           Data.Maybe (fromJust)
 import           Data.Monoid ((<>))
 import qualified Data.Text as T
@@ -859,7 +858,7 @@ main = do
   hspec $ do
     describe "get rates" $ do
       it "gets the correct rates" $ do
-        (product, productId) <- createBaseProductHelper config exampleCreateBaseProduct
+        (_, productId) <- createBaseProductHelper config exampleCreateBaseProduct
         let getRt = mkGetRate (RateOptions USD GroupByAll Nothing Nothing Nothing (Just IgnoreUnknownSkus) (CanSplit 1) WarehouseAreaUS Nothing) (RateOrder exampleShipTo exampleItems)
         result <- shipwire config $ createRateRequest getRt
         result `shouldSatisfy` isRight
@@ -870,7 +869,7 @@ main = do
 
     describe "get stock info" $ do
       it "gets stock info with optional args" $ do
-        (product, productId) <- createBaseProductHelper config exampleCreateBaseProduct
+        (_, productId) <- createBaseProductHelper config exampleCreateBaseProduct
         result <- shipwire config $ getStockInfo -&- (SKU "HspecTest3")
         _ <- shipwire config $ retireProducts $ ProductsToRetire [ProductId productId]
         result `shouldSatisfy` isRight
@@ -880,7 +879,7 @@ main = do
 
     describe "get receivings" $ do
       it "gets an itemized list of receivings with optional args" $ do
-        (product, productId) <- createBaseProductHelper config exampleCreateBaseProduct
+        (_, productId) <- createBaseProductHelper config exampleCreateBaseProduct
         (_, receivingId) <- createReceivingHelper config exampleCreateReceiving
         result <- shipwire config $ getReceivings -&- (ExpandReceivingsParam [ExpandAll])
                                                   -&- (ReceivingStatusParams [StatusCanceled])
@@ -892,7 +891,7 @@ main = do
 
     describe "create a new receiving" $ do
       it "creates a new receiving with optional args" $ do
-        (product, productId) <- createBaseProductHelper config exampleCreateBaseProduct
+        (_, productId) <- createBaseProductHelper config exampleCreateBaseProduct
         (receiving, receivingId) <- createReceivingHelper config exampleCreateReceiving
         receiving `shouldSatisfy` isRight
         _ <- shipwire config $ cancelReceiving receivingId
@@ -902,7 +901,7 @@ main = do
         receivingsResponseWarnings `shouldBe` Nothing
 
       it "doesn't create a receiving with bad JSON" $ do
-        (product, productId) <- createBaseProductHelper config exampleCreateBaseProduct
+        (_, productId) <- createBaseProductHelper config exampleCreateBaseProduct
         result <- shipwire config $ createReceiving exampleBadCreateReceiving
         _ <- shipwire config $ retireProducts $ ProductsToRetire [ProductId productId]
         let Right ReceivingsResponse {..} = result
@@ -918,7 +917,7 @@ main = do
 
     describe "get information about a receiving" $ do
       it "gets info about a receiving" $ do
-        (product, productId) <- createBaseProductHelper config exampleCreateBaseProduct
+        (_, productId) <- createBaseProductHelper config exampleCreateBaseProduct
         (_, receivingId) <- createReceivingHelper config exampleCreateReceiving
         result <- shipwire config $ getReceiving receivingId -&- (ExpandReceivingsParam [ExpandHolds, ExpandItems])
         result `shouldSatisfy` isRight
@@ -930,7 +929,7 @@ main = do
 
     describe "modify information about a receiving" $ do
       it "modifies info about a receiving" $ do
-        (product, productId) <- createBaseProductHelper config exampleCreateBaseProduct
+        (_, productId) <- createBaseProductHelper config exampleCreateBaseProduct
         (_, receivingId) <- createReceivingHelper config exampleCreateReceiving
         result <- shipwire config $ modifyReceiving receivingId exampleModifiedReceiving
         result `shouldSatisfy` isRight
@@ -948,7 +947,7 @@ main = do
 
     describe "cancel a receiving" $ do
       it "cancels a receiving" $ do
-        (product, productId) <- createBaseProductHelper config exampleCreateBaseProduct
+        (_, productId) <- createBaseProductHelper config exampleCreateBaseProduct
         (_, receivingId) <- createReceivingHelper config exampleCreateReceiving
         result <- shipwire config $ cancelReceiving receivingId
         result `shouldSatisfy` isRight
@@ -959,7 +958,7 @@ main = do
 
     describe "cancel shipping labels" $ do
       it "cancels shipping labels on a receiving" $ do
-        (product, productId) <- createBaseProductHelper config exampleCreateBaseProduct
+        (_, productId) <- createBaseProductHelper config exampleCreateBaseProduct
         (_, receivingId) <- createReceivingHelper config exampleCreateReceiving
         result <- shipwire config $ cancelReceivingLabels receivingId
         result `shouldSatisfy` isRight
@@ -970,7 +969,7 @@ main = do
 
     describe "get list of holds for a receiving" $ do
       it "gets a list of holds for a receiving" $ do
-        (product, productId) <- createBaseProductHelper config exampleCreateBaseProduct
+        (_, productId) <- createBaseProductHelper config exampleCreateBaseProduct
         (_, receivingId) <- createReceivingHelper config exampleCreateReceiving
         result <- shipwire config $ getReceivingHolds receivingId -&- IncludeCleared
         result `shouldSatisfy` isRight
@@ -982,7 +981,7 @@ main = do
 
     describe "get email recipients and instructions for a receiving" $ do
       it "gets email recipients and instructions for a receiving" $ do
-        (product, productId) <- createBaseProductHelper config exampleCreateBaseProduct
+        (_, productId) <- createBaseProductHelper config exampleCreateBaseProduct
         (_, receivingId) <- createReceivingHelper config exampleCreateReceiving
         result <- shipwire config $ getReceivingInstructionsRecipients receivingId
         result `shouldSatisfy` isRight
@@ -994,7 +993,7 @@ main = do
 
     describe "get contents of a receiving" $ do
       it "gets contents of a receiving" $ do
-        (product, productId) <- createBaseProductHelper config exampleCreateBaseProduct
+        (_, productId) <- createBaseProductHelper config exampleCreateBaseProduct
         (_, receivingId) <- createReceivingHelper config exampleCreateReceiving
         result <- shipwire config $ getReceivingItems receivingId
         result `shouldSatisfy` isRight
@@ -1006,7 +1005,7 @@ main = do
 
     describe "get shipping dimension and container information" $ do
       it "gets shipping dimension and container infromation" $ do
-        (product, productId) <- createBaseProductHelper config exampleCreateBaseProduct
+        (_, productId) <- createBaseProductHelper config exampleCreateBaseProduct
         (_, receivingId) <- createReceivingHelper config exampleCreateReceiving
         result <- shipwire config $ getReceivingShipments receivingId
         result `shouldSatisfy` isRight
@@ -1018,7 +1017,7 @@ main = do
 
     describe "get tracking information for a receiving" $ do
       it "gets tracking information for a receiving" $ do
-        (product, productId) <- createBaseProductHelper config exampleCreateBaseProduct
+        (_, productId) <- createBaseProductHelper config exampleCreateBaseProduct
         (_, receivingId) <- createReceivingHelper config exampleCreateReceiving
         result <- shipwire config $ getReceivingTrackings receivingId
         result `shouldSatisfy` isRight
@@ -1030,7 +1029,7 @@ main = do
 
     describe "get labels information for a receiving" $ do
       it "gets labels information for a receiving" $ do
-        (product, productId) <- createBaseProductHelper config exampleCreateBaseProduct
+        (_, productId) <- createBaseProductHelper config exampleCreateBaseProduct
         (_, receivingId) <- createReceivingHelper config exampleCreateReceiving
         result <- shipwire config $ getReceivingLabels receivingId
         result `shouldSatisfy` isRight
@@ -1042,7 +1041,7 @@ main = do
 
     describe "get an itemized list of products" $ do
       it "gets an itemized list of products" $ do
-        (product, productId) <- createBaseProductHelper config exampleCreateBaseProduct
+        (_, productId) <- createBaseProductHelper config exampleCreateBaseProduct
         result <- shipwire config $ getProducts -&- (ExpandProductsParam [ExpandEnqueuedDimensions])
         result `shouldSatisfy` isRight
         _ <- shipwire config $ retireProducts $ ProductsToRetire [ProductId productId]
@@ -1052,16 +1051,16 @@ main = do
 
     describe "create a product" $ do
       it "creates all possible product classifications" $ do
-        (product, productId) <- createBaseProductHelper config exampleCreateBaseProduct
-        product `shouldSatisfy` isRight
-        let response@(Right GetProductsResponse {..}) = product
+        (prd, productId) <- createBaseProductHelper config exampleCreateBaseProduct
+        prd `shouldSatisfy` isRight
+        let response@(Right GetProductsResponse {..}) = prd
         _ <- shipwire config $ retireProducts $ ProductsToRetire [ProductId productId]
         gprWarnings `shouldBe` Nothing
         gprErrors `shouldBe` Nothing
 
     describe "modify products" $ do
       it "modifies several previously created products" $ do
-        (product, productId) <- createBaseProductHelper config exampleCreateBaseProduct
+        (_, productId) <- createBaseProductHelper config exampleCreateBaseProduct
         result <- shipwire config $ modifyProducts (exampleModifyProducts productId)
         result `shouldSatisfy` isRight
         let Right ModifyProductsResponse {..} = result
@@ -1071,7 +1070,7 @@ main = do
 
     describe "modify a product" $ do
       it "modifies a single product" $ do
-        (product, productId) <- createBaseProductHelper config exampleCreateBaseProduct
+        (_, productId) <- createBaseProductHelper config exampleCreateBaseProduct
         result <- shipwire config $ modifyProduct (exampleModifyProduct productId) (Id productId)
         result `shouldSatisfy` isRight
         let Right ModifyProductsResponse {..} = result
@@ -1081,7 +1080,7 @@ main = do
 
     describe "get a product" $ do
       it "gets information about a single product" $ do
-        (product, productId) <- createBaseProductHelper config exampleCreateBaseProduct
+        (_, productId) <- createBaseProductHelper config exampleCreateBaseProduct
         result <- shipwire config $ getProduct $ Id productId
         result `shouldSatisfy` isRight
         _ <- shipwire config $ retireProducts $ ProductsToRetire [ProductId productId]

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -18,7 +18,7 @@ mkGetRate :: RateOptions -> RateOrder -> GetRate
 mkGetRate ropts rord = GetRate ropts rord
 
 exampleItems :: Items
-exampleItems = [ItemInfo ((SKU "HspecTest"), Quantity 5)]
+exampleItems = [ItemInfo ((SKU "HspecTest3"), Quantity 5)]
 
 exampleShipTo :: ShipTo
 exampleShipTo =
@@ -48,7 +48,7 @@ exampleCreateReceiving =
        [ReceivingShipment Nothing Nothing Nothing Nothing $ Type "box"])
     Nothing
     Nothing
-    (ReceivingItems [ReceivingItem (SKU "HspecTest") (Quantity 3)])
+    (ReceivingItems [ReceivingItem (SKU "HspecTest3") (Quantity 3)])
     (ReceivingShipFrom
        Nothing
        (Name "Stephen Alexander")
@@ -104,7 +104,7 @@ exampleModifiedReceiving =
        [ReceivingShipment Nothing Nothing Nothing Nothing $ Type "box"])
     Nothing
     Nothing
-    (ReceivingItems [ReceivingItem (SKU "HspecTest") (Quantity 3)])
+    (ReceivingItems [ReceivingItem (SKU "HspecTest3") (Quantity 3)])
     (ReceivingShipFrom
        Nothing
        (Name "Stephen Alexander")
@@ -408,7 +408,7 @@ exampleCreateBaseProduct :: [CreateProductsWrapper]
 exampleCreateBaseProduct =
   [ CpwBaseProduct $
     BaseProduct
-      (SKU "HspecTest")
+      (SKU "HspecTest3")
       Nothing
       (BaseProductClassification)
       (Description "Hspec test product3")

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -14,7 +14,7 @@ mkGetRate :: RateOptions -> RateOrder -> GetRate
 mkGetRate ropts rord = GetRate ropts rord
 
 exampleItems :: Items
-exampleItems = [ItemInfo ((SKU "Ballasttest"), Quantity 1)]
+exampleItems = [ItemInfo ((SKU "HspecTest"), Quantity 1)]
 
 exampleShipTo :: ShipTo
 exampleShipTo =
@@ -44,7 +44,7 @@ exampleCreateReceiving =
        [ReceivingShipment Nothing Nothing Nothing Nothing $ Type "box"])
     Nothing
     Nothing
-    (ReceivingItems [ReceivingItem (SKU "Ballasttest") (Quantity 3)])
+    (ReceivingItems [ReceivingItem (SKU "HspecTest") (Quantity 3)])
     (ReceivingShipFrom
        Nothing
        (Name "Stephen Alexander")
@@ -72,7 +72,7 @@ exampleBadCreateReceiving =
        [ReceivingShipment Nothing Nothing Nothing Nothing $ Type "box"])
     Nothing
     Nothing
-    (ReceivingItems [ReceivingItem (SKU "Ballasttest") (Quantity 0)])
+    (ReceivingItems [ReceivingItem (SKU "HspecTest") (Quantity 0)])
     (ReceivingShipFrom
        Nothing
        (Name "Stephen Alexander")
@@ -100,7 +100,7 @@ exampleModifiedReceiving =
        [ReceivingShipment Nothing Nothing Nothing Nothing $ Type "box"])
     Nothing
     Nothing
-    (ReceivingItems [ReceivingItem (SKU "Ballasttest") (Quantity 3)])
+    (ReceivingItems [ReceivingItem (SKU "HspecTest") (Quantity 3)])
     (ReceivingShipFrom
        Nothing
        (Name "Stephen Alexander")
@@ -112,6 +112,122 @@ exampleModifiedReceiving =
        (Country "Modified Country")
        (Phone "12346"))
     Nothing
+
+exampleCreateProduct :: [CreateProductsWrapper]
+exampleCreateProduct = [CpwBaseProduct $ BaseProduct
+                          (SKU "HspecTest")
+                          Nothing
+                          (BaseProductClassification)
+                          (Description "Hspec test product")
+                          (Just $ HsCode "010612")
+                          (CountryOfOrigin "US")
+                          (Category "TOYS_SPORTS_HOBBIES")
+                          (BatteryConfiguration "ISBATTERY")
+                          (Values 
+                            (CostValue 1)
+                            (WholesaleValue 2)
+                            (RetailValue 4)
+                            (CostCurrency "USD")
+                            (WholesaleCurrency "USD")
+                            (RetailCurrency "USD")
+                          )
+                          (BaseProductAlternateNames [BaseProductAlternateName (Name "HspecAlt")])
+                          (BaseProductDimensions 
+                            (BaseProductLength 10)
+                            (BaseProductWidth 10)
+                            (BaseProductHeight 10)
+                            (BaseProductWeight 10)
+                          )
+                          (BaseProductTechnicalData 
+                            (BaseProductTechnicalDataResource 
+                                (BatteryType "ALKALINE")
+                                (BatteryWeight 3)
+                                (NumberOfBatteries 5)
+                                (Capacity 6)
+                                (NumberOfCells 7)
+                                (CapacityUnit "WATTHOUR")
+                            )
+                          )
+                          (BaseProductFlags 
+                            PackagedReadyToShip
+                            Fragile
+                            NotDangerous
+                            NotPerishable
+                            NotMedia
+                            NotAdult
+                            NotLiquid
+                            HasInnerPack
+                            HasMasterCase
+                            HasPallet
+                          )
+                          (BaseProductInnerPack 
+                            (IndividualItemsPerCase 2)
+                            (ExternalId "narp22")
+                            (SKU "singleInner2")
+                            (Description "InnerDec")
+                            (Values 
+                                (CostValue 1)
+                                (WholesaleValue 2)
+                                (RetailValue 4)
+                                (CostCurrency "USD")
+                                (WholesaleCurrency "USD")
+                                (RetailCurrency "USD")
+                            )
+                            (BaseProductDimensions 
+                                (BaseProductLength 20)
+                                (BaseProductWidth 20)
+                                (BaseProductHeight 20)
+                                (BaseProductWeight 20)
+                            )
+                            (BaseProductInnerPackFlags 
+                                NotPackagedReadyToShip
+                            )
+                          )
+                          (BaseProductMasterCase 
+                            (IndividualItemsPerCase 10)
+                            (ExternalId "narp3")
+                            (SKU "singleMaster2")
+                            (Description "masterdesc")
+                            (Values
+                                (CostValue 1)
+                                (WholesaleValue 2)
+                                (RetailValue 4)
+                                (CostCurrency "USD")
+                                (WholesaleCurrency "USD")
+                                (RetailCurrency "USD")
+                            )
+                            (BaseProductDimensions 
+                                (BaseProductLength 30)
+                                (BaseProductWidth 30)
+                                (BaseProductHeight 30)
+                                (BaseProductWeight 30)
+                            )
+                            (BaseProductMasterCaseFlags PackagedReadyToShip)
+                          )
+                          (BaseProductPallet 
+                            (IndividualItemsPerCase 1000)
+                            (ExternalId "narp4")
+                            (SKU "singlePallet2")
+                            (Description "palletdesc")
+                            (Values 
+                                (CostValue 1)
+                                (WholesaleValue 2)
+                                (RetailValue 4)
+                                (CostCurrency "USD")
+                                (WholesaleCurrency "USD")
+                                (RetailCurrency "USD")
+                            )
+                            (BaseProductDimensions 
+                                (BaseProductLength 40)
+                                (BaseProductWidth 40)
+                                (BaseProductHeight 40)
+                                (BaseProductWeight 40)
+                            )
+                            (BaseProductPalletFlags 
+                                NotPackagedReadyToShip
+                            )
+                          )
+                        ]
 
 createReceivingHelper :: ShipwireConfig -> CreateReceiving -> IO (Either ShipwireError (ShipwireReturn CreateReceivingRequest), ReceivingId)
 createReceivingHelper conf cr = do
@@ -131,7 +247,7 @@ main = do
   hspec $ do
     describe "get rates" $ do
       it "gets the correct rates" $ do
-        let getRt = mkGetRate (RateOptions USD GroupByAll (CanSplit 1) WarehouseAreaUS Nothing) (RateOrder exampleShipTo exampleItems)
+        let getRt = mkGetRate (RateOptions USD GroupByAll Nothing Nothing Nothing (Just IgnoreUnknownSkus) (CanSplit 1) WarehouseAreaUS Nothing) (RateOrder exampleShipTo exampleItems)
         result <- shipwire config $ createRateRequest getRt
         result `shouldSatisfy` isRight
         let Right RateResponse{..} = result
@@ -140,7 +256,7 @@ main = do
 
     describe "get stock info" $ do
       it "gets stock info with optional args" $ do
-        result <- shipwire config $ getStockInfo -&- (SKU "Ballasttest")
+        result <- shipwire config $ getStockInfo -&- (SKU "HspecTest")
         result `shouldSatisfy` isRight
 
     describe "get receivings" $ do
@@ -261,3 +377,11 @@ main = do
         let Right GetProductsResponse {..} = result
         gprWarnings `shouldBe` Nothing
         gprErrors `shouldBe` Nothing
+
+    -- describe "create a product" $ do
+    --   it "creates a product" $ do
+    --     result <- shipwire config $ createProduct exampleCreateProduct
+    --     result `shouldSatisfy` isRight
+    --     let Right GetProductsResponse {..} = result
+    --     gprWarnings `shouldBe` Nothing
+    --     gprErrors `shouldBe` Nothing

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -695,6 +695,10 @@ unwrapPwVirtualKit (_:xs) = unwrapPwVirtualKit xs
 main :: IO ()
 main = do
   config <- sandboxEnvConfig
+  allProducts <- shipwire config $ getProducts
+  let gpr@(Right GetProductsResponse {..}) = allProducts
+  ids <- getProductIds $ fromRight gpr
+  _ <- shipwire config $ retireProducts $ ProductsToRetire (map ProductId ids)
   -- We need to create a dummy product to be able to create a receiving
   (_, productId) <- createProductHelper config exampleCreateBaseProduct
   (receiving, receivingId) <- createReceivingHelper config exampleCreateReceiving
@@ -837,9 +841,9 @@ main = do
       it "creates all possible product classifications" $ do
         result <- shipwire config $ createProduct (exampleCreateProduct productId)
         result `shouldSatisfy` isRight
-        let gpr@(Right GetProductsResponse {..}) = result
-        ids <- getProductIds $ fromRight gpr
-        _ <- shipwire config $ retireProducts $ ProductsToRetire (map ProductId (productId : ids))
+        let response@(Right GetProductsResponse {..}) = result
+        productIds <- getProductIds $ fromRight response
+        _ <- shipwire config $ retireProducts $ ProductsToRetire (map ProductId (productId : productIds))
         gprWarnings `shouldBe` Nothing
         gprErrors `shouldBe` Nothing
 

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -295,7 +295,7 @@ exampleCreateProduct productId =
                           (Just $ CountryOfOrigin "US")
                           (Category "TOYS_SPORTS_HOBBIES")
                           (BatteryConfiguration "ISBATTERY")
-                          (Values 
+                          (Values
                             (CostValue 1)
                             (WholesaleValue 2)
                             (RetailValue 4)
@@ -304,14 +304,14 @@ exampleCreateProduct productId =
                             (Just $ RetailCurrency "USD")
                           )
                           (BaseProductAlternateNames [BaseProductAlternateName (Name "HspecAlt2")])
-                          (BaseProductDimensions 
+                          (BaseProductDimensions
                             (BaseProductLength 10)
                             (BaseProductWidth 10)
                             (BaseProductHeight 10)
                             (BaseProductWeight 10)
                           )
-                          (BaseProductTechnicalData 
-                            (BaseProductTechnicalDataBattery 
+                          (BaseProductTechnicalData
+                            (BaseProductTechnicalDataBattery
                                 (Just $ BatteryType "ALKALINE")
                                 (Just $ BatteryWeight 3)
                                 (Just $ NumberOfBatteries 5)
@@ -320,7 +320,7 @@ exampleCreateProduct productId =
                                 (Just $ CapacityUnit "WATTHOUR")
                             )
                           )
-                          (BaseProductFlags 
+                          (BaseProductFlags
                             PackagedReadyToShip
                             Fragile
                             NotDangerous
@@ -332,12 +332,12 @@ exampleCreateProduct productId =
                             HasMasterCase
                             HasPallet
                           )
-                          (BaseProductInnerPack 
+                          (BaseProductInnerPack
                             (IndividualItemsPerCase 2)
                             (Just $ ExternalId "narp222")
                             (SKU "singleInner22")
                             (Description "InnerDec2")
-                            (Values 
+                            (Values
                                 (CostValue 1)
                                 (WholesaleValue 2)
                                 (RetailValue 4)
@@ -345,17 +345,17 @@ exampleCreateProduct productId =
                                 (Just $ WholesaleCurrency "USD")
                                 (Just $ RetailCurrency "USD")
                             )
-                            (BaseProductDimensions 
+                            (BaseProductDimensions
                                 (BaseProductLength 20)
                                 (BaseProductWidth 20)
                                 (BaseProductHeight 20)
                                 (BaseProductWeight 20)
                             )
-                            (BaseProductInnerPackFlags 
+                            (BaseProductInnerPackFlags
                                 NotPackagedReadyToShip
                             )
                           )
-                          (BaseProductMasterCase 
+                          (BaseProductMasterCase
                             (IndividualItemsPerCase 10)
                             (Just $ ExternalId "narp33")
                             (SKU "singleMaster23")
@@ -368,7 +368,7 @@ exampleCreateProduct productId =
                                 (Just $ WholesaleCurrency "USD")
                                 (Just $ RetailCurrency "USD")
                             )
-                            (BaseProductDimensions 
+                            (BaseProductDimensions
                                 (BaseProductLength 30)
                                 (BaseProductWidth 30)
                                 (BaseProductHeight 30)
@@ -376,12 +376,12 @@ exampleCreateProduct productId =
                             )
                             (BaseProductMasterCaseFlags PackagedReadyToShip)
                           )
-                          (BaseProductPallet 
+                          (BaseProductPallet
                             (IndividualItemsPerCase 1000)
                             (Just $ ExternalId "narp42")
                             (SKU "singlePallet22")
                             (Description "palletdesc2")
-                            (Values 
+                            (Values
                                 (CostValue 1)
                                 (WholesaleValue 2)
                                 (RetailValue 4)
@@ -389,13 +389,13 @@ exampleCreateProduct productId =
                                 (Just $ WholesaleCurrency "USD")
                                 (Just $ RetailCurrency "USD")
                             )
-                            (BaseProductDimensions 
+                            (BaseProductDimensions
                                 (BaseProductLength 40)
                                 (BaseProductWidth 40)
                                 (BaseProductHeight 40)
                                 (BaseProductWeight 40)
                             )
-                            (BaseProductPalletFlags 
+                            (BaseProductPalletFlags
                                 NotPackagedReadyToShip
                             )
                           )
@@ -500,7 +500,7 @@ exampleCreateBaseProduct =
             (BaseProductWeight 40))
          (BaseProductPalletFlags NotPackagedReadyToShip))
   ]
-  
+
 createReceivingHelper :: ShipwireConfig -> CreateReceiving -> IO (Either ShipwireError (ShipwireReturn CreateReceivingRequest), ReceivingId)
 createReceivingHelper conf cr = do
   receiving <- shipwire conf $ createReceiving cr

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -122,7 +122,7 @@ exampleCreateProduct productId =
                           (Description "This is a virtual kit test")
                           (VirtualKitContent
                             [(VirtualKitContentObject
-                              (ProductId productId)
+                              (Just $ ProductId productId)
                               Nothing
                               (Quantity 5)
                             )
@@ -134,23 +134,23 @@ exampleCreateProduct productId =
                           (KitClassification)
                           (Description "This is a kit test")
                           (BatteryConfiguration "HASLOOSEBATTERY")
-                          (HsCode "010612")
-                          (CountryOfOrigin "US")
+                          (Just $ HsCode "010612")
+                          (Just $ CountryOfOrigin "US")
                           (KitValues
                             (CostValue 1)
                             (WholesaleValue 2)
                             (RetailValue 4)
-                            (CostCurrency "USD")
-                            (WholesaleCurrency "USD")
-                            (RetailCurrency "USD")
+                            (Just $ CostCurrency "USD")
+                            (Just $ WholesaleCurrency "USD")
+                            (Just $ RetailCurrency "USD")
                           )
-                          (KitAlternateNames [KitAlternateName (Name "HspecTestAlt")])
+                          (Just $ KitAlternateNames [KitAlternateName (Name "HspecTestAlt")])
                           -- KitContentObject needs to include ids of other products
                           -- included in this kit. We use a helper function to create a
                           -- product and get back that product's id.
                           (KitContent
                             [KitContentObject
-                              (ProductId productId)
+                              (Just $ ProductId productId)
                               Nothing
                               (Quantity 5)
                             ]
@@ -161,14 +161,14 @@ exampleCreateProduct productId =
                             (KitHeight 2)
                             (KitWeight 2)
                           )
-                          (KitTechnicalData
+                          (Just $ KitTechnicalData
                             (KitTechnicalDataBattery
                               (BatteryType "ALKALINE")
-                              (BatteryWeight 3)
-                              (NumberOfBatteries 5)
-                              (Capacity 6)
-                              (NumberOfCells 7)
-                              (CapacityUnit "WATTHOUR")
+                              (Just $ BatteryWeight 3)
+                              (Just $ NumberOfBatteries 5)
+                              (Just $ Capacity 6)
+                              (Just $ NumberOfCells 7)
+                              (Just $ CapacityUnit "WATTHOUR")
                             )
                           )
                           (KitFlags
@@ -192,9 +192,9 @@ exampleCreateProduct productId =
                              (CostValue 1)
                              (WholesaleValue 2)
                              (RetailValue 4)
-                             (CostCurrency "USD")
-                             (WholesaleCurrency "USD")
-                             (RetailCurrency "USD")
+                             (Just $ CostCurrency "USD")
+                             (Just $ WholesaleCurrency "USD")
+                             (Just $ RetailCurrency "USD")
                            )
                            (KitDimensions
                              (KitLength 2)
@@ -214,9 +214,9 @@ exampleCreateProduct productId =
                               (CostValue 1)
                               (WholesaleValue 2)
                               (RetailValue 4)
-                              (CostCurrency "USD")
-                              (WholesaleCurrency "USD")
-                              (RetailCurrency "USD")
+                              (Just $ CostCurrency "USD")
+                              (Just $ WholesaleCurrency "USD")
+                              (Just $ RetailCurrency "USD")
                             )
                             (KitDimensions
                               (KitLength 4)
@@ -236,9 +236,9 @@ exampleCreateProduct productId =
                               (CostValue 1)
                               (WholesaleValue 2)
                               (RetailValue 4)
-                              (CostCurrency "USD")
-                              (WholesaleCurrency "USD")
-                              (RetailCurrency "USD")
+                              (Just $ CostCurrency "USD")
+                              (Just $ WholesaleCurrency "USD")
+                              (Just $ RetailCurrency "USD")
                             )
                             (KitDimensions
                               (KitLength 8)
@@ -256,7 +256,7 @@ exampleCreateProduct productId =
                           (MarketingInsertClassification)
                           (Description "Hspec test marketing insert2")
                           (InclusionRuleType "CUSTOM")
-                          (MarketingInsertAlternateNames [MarketingInsertAlternateName (Name "HspecMI22")])
+                          (Just $ MarketingInsertAlternateNames [MarketingInsertAlternateName (Name "HspecMI22")])
                           (MarketingInsertDimensions
                             (MarketingInsertLength 0.1)
                             (MarketingInsertWidth 0.1)
@@ -266,12 +266,12 @@ exampleCreateProduct productId =
                           (MarketingInsertFlags
                             ShouldNotFold
                           )
-                          (MarketingInsertInclusionRules
-                            (InsertAfterDate "3016-02-15T13:04:26-05:00")
-                            (InsertBeforeDate "3016-02-15T13:04:26-05:00")
-                            (InsertWhenWorthValue 5)
-                            (InsertWhenQuantity 5)
-                            (InsertWhenWorthCurrency "USD")
+                          (Just $ MarketingInsertInclusionRules
+                            (Just $ InsertAfterDate "3016-02-15T13:04:26-05:00")
+                            (Just $ InsertBeforeDate "3016-02-15T13:04:26-05:00")
+                            (Just $ InsertWhenWorthValue 5)
+                            (Just $ InsertWhenQuantity 5)
+                            (Just $ InsertWhenWorthCurrency "USD")
                           )
                           (MarketingInsertMasterCase
                             (IndividualItemsPerCase 10)
@@ -291,16 +291,16 @@ exampleCreateProduct productId =
                           (BaseProductClassification)
                           (Description "Hspec test product2")
                           (Just $ HsCode "010612")
-                          (CountryOfOrigin "US")
+                          (Just $ CountryOfOrigin "US")
                           (Category "TOYS_SPORTS_HOBBIES")
                           (BatteryConfiguration "ISBATTERY")
                           (Values 
                             (CostValue 1)
                             (WholesaleValue 2)
                             (RetailValue 4)
-                            (CostCurrency "USD")
-                            (WholesaleCurrency "USD")
-                            (RetailCurrency "USD")
+                            (Just $ CostCurrency "USD")
+                            (Just $ WholesaleCurrency "USD")
+                            (Just $ RetailCurrency "USD")
                           )
                           (BaseProductAlternateNames [BaseProductAlternateName (Name "HspecAlt2")])
                           (BaseProductDimensions 
@@ -311,12 +311,12 @@ exampleCreateProduct productId =
                           )
                           (BaseProductTechnicalData 
                             (BaseProductTechnicalDataBattery 
-                                (BatteryType "ALKALINE")
-                                (BatteryWeight 3)
-                                (NumberOfBatteries 5)
-                                (Capacity 6)
-                                (NumberOfCells 7)
-                                (CapacityUnit "WATTHOUR")
+                                (Just $ BatteryType "ALKALINE")
+                                (Just $ BatteryWeight 3)
+                                (Just $ NumberOfBatteries 5)
+                                (Just $ Capacity 6)
+                                (Just $ NumberOfCells 7)
+                                (Just $ CapacityUnit "WATTHOUR")
                             )
                           )
                           (BaseProductFlags 
@@ -333,16 +333,16 @@ exampleCreateProduct productId =
                           )
                           (BaseProductInnerPack 
                             (IndividualItemsPerCase 2)
-                            (ExternalId "narp222")
+                            (Just $ ExternalId "narp222")
                             (SKU "singleInner22")
                             (Description "InnerDec2")
                             (Values 
                                 (CostValue 1)
                                 (WholesaleValue 2)
                                 (RetailValue 4)
-                                (CostCurrency "USD")
-                                (WholesaleCurrency "USD")
-                                (RetailCurrency "USD")
+                                (Just $ CostCurrency "USD")
+                                (Just $ WholesaleCurrency "USD")
+                                (Just $ RetailCurrency "USD")
                             )
                             (BaseProductDimensions 
                                 (BaseProductLength 20)
@@ -356,16 +356,16 @@ exampleCreateProduct productId =
                           )
                           (BaseProductMasterCase 
                             (IndividualItemsPerCase 10)
-                            (ExternalId "narp33")
+                            (Just $ ExternalId "narp33")
                             (SKU "singleMaster23")
                             (Description "masterdesc3")
                             (Values
                                 (CostValue 1)
                                 (WholesaleValue 2)
                                 (RetailValue 4)
-                                (CostCurrency "USD")
-                                (WholesaleCurrency "USD")
-                                (RetailCurrency "USD")
+                                (Just $ CostCurrency "USD")
+                                (Just $ WholesaleCurrency "USD")
+                                (Just $ RetailCurrency "USD")
                             )
                             (BaseProductDimensions 
                                 (BaseProductLength 30)
@@ -377,16 +377,16 @@ exampleCreateProduct productId =
                           )
                           (BaseProductPallet 
                             (IndividualItemsPerCase 1000)
-                            (ExternalId "narp42")
+                            (Just $ ExternalId "narp42")
                             (SKU "singlePallet22")
                             (Description "palletdesc2")
                             (Values 
                                 (CostValue 1)
                                 (WholesaleValue 2)
                                 (RetailValue 4)
-                                (CostCurrency "USD")
-                                (WholesaleCurrency "USD")
-                                (RetailCurrency "USD")
+                                (Just $ CostCurrency "USD")
+                                (Just $ WholesaleCurrency "USD")
+                                (Just $ RetailCurrency "USD")
                             )
                             (BaseProductDimensions 
                                 (BaseProductLength 40)
@@ -409,16 +409,16 @@ exampleCreateBaseProduct =
       (BaseProductClassification)
       (Description "Hspec test product3")
       (Just $ HsCode "010612")
-      (CountryOfOrigin "US")
+      (Just $ CountryOfOrigin "US")
       (Category "TOYS_SPORTS_HOBBIES")
       (BatteryConfiguration "ISBATTERY")
       (Values
          (CostValue 1)
          (WholesaleValue 2)
          (RetailValue 4)
-         (CostCurrency "USD")
-         (WholesaleCurrency "USD")
-         (RetailCurrency "USD"))
+         (Just $ CostCurrency "USD")
+         (Just $ WholesaleCurrency "USD")
+         (Just $ RetailCurrency "USD"))
       (BaseProductAlternateNames [BaseProductAlternateName (Name "HspecAlt3")])
       (BaseProductDimensions
          (BaseProductLength 10)
@@ -427,12 +427,12 @@ exampleCreateBaseProduct =
          (BaseProductWeight 10))
       (BaseProductTechnicalData
          (BaseProductTechnicalDataBattery
-            (BatteryType "ALKALINE")
-            (BatteryWeight 3)
-            (NumberOfBatteries 5)
-            (Capacity 6)
-            (NumberOfCells 7)
-            (CapacityUnit "WATTHOUR")))
+            (Just $ BatteryType "ALKALINE")
+            (Just $ BatteryWeight 3)
+            (Just $ NumberOfBatteries 5)
+            (Just $ Capacity 6)
+            (Just $ NumberOfCells 7)
+            (Just $ CapacityUnit "WATTHOUR")))
       (BaseProductFlags
          PackagedReadyToShip
          Fragile
@@ -446,16 +446,16 @@ exampleCreateBaseProduct =
          HasPallet)
       (BaseProductInnerPack
          (IndividualItemsPerCase 2)
-         (ExternalId "narp55")
+         (Just $ ExternalId "narp55")
          (SKU "singleInner3")
          (Description "InnerDesc3")
          (Values
             (CostValue 1)
             (WholesaleValue 2)
             (RetailValue 4)
-            (CostCurrency "USD")
-            (WholesaleCurrency "USD")
-            (RetailCurrency "USD"))
+            (Just $ CostCurrency "USD")
+            (Just $ WholesaleCurrency "USD")
+            (Just $ RetailCurrency "USD"))
          (BaseProductDimensions
             (BaseProductLength 20)
             (BaseProductWidth 20)
@@ -464,16 +464,16 @@ exampleCreateBaseProduct =
          (BaseProductInnerPackFlags NotPackagedReadyToShip))
       (BaseProductMasterCase
          (IndividualItemsPerCase 10)
-         (ExternalId "narp66")
+         (Just $ ExternalId "narp66")
          (SKU "singleMaster4")
          (Description "masterdesc4")
          (Values
             (CostValue 1)
             (WholesaleValue 2)
             (RetailValue 4)
-            (CostCurrency "USD")
-            (WholesaleCurrency "USD")
-            (RetailCurrency "USD"))
+            (Just $ CostCurrency "USD")
+            (Just $ WholesaleCurrency "USD")
+            (Just $ RetailCurrency "USD"))
          (BaseProductDimensions
             (BaseProductLength 30)
             (BaseProductWidth 30)
@@ -482,16 +482,16 @@ exampleCreateBaseProduct =
          (BaseProductMasterCaseFlags PackagedReadyToShip))
       (BaseProductPallet
          (IndividualItemsPerCase 1000)
-         (ExternalId "narp77")
+         (Just $ ExternalId "narp77")
          (SKU "singlePallet3")
          (Description "palletdesc3")
          (Values
             (CostValue 1)
             (WholesaleValue 2)
             (RetailValue 4)
-            (CostCurrency "USD")
-            (WholesaleCurrency "USD")
-            (RetailCurrency "USD"))
+            (Just $ CostCurrency "USD")
+            (Just $ WholesaleCurrency "USD")
+            (Just $ RetailCurrency "USD"))
          (BaseProductDimensions
             (BaseProductLength 40)
             (BaseProductWidth 40)
@@ -504,22 +504,22 @@ createReceivingHelper :: ShipwireConfig -> CreateReceiving -> IO (Either Shipwir
 createReceivingHelper conf cr = do
   receiving <- shipwire conf $ createReceiving cr
   let Right ReceivingsResponse {..} = receiving
-  let ReceivingsResource {..} = receivingsResponseResource
-  let ReceivingsItems {..} = receivingsResponseItems
-  let ReceivingsItem {..} = last unReceivingsItems
-  let ReceivingsItemResource {..} = receivingsItemResource
-  let receivingId = T.pack $ show $ unId rirId
+      ReceivingsResource {..} = receivingsResponseResource
+      ReceivingsItems {..} = receivingsResponseItems
+      ReceivingsItem {..} = last unReceivingsItems
+      ReceivingsItemResource {..} = receivingsItemResource
+      receivingId = T.pack $ show $ unId rirId
   return (receiving, ReceivingId receivingId)
 
 createProductHelper :: ShipwireConfig -> [CreateProductsWrapper] -> IO (Either ShipwireError (ShipwireReturn CreateProductsRequest), Integer)
 createProductHelper conf cp = do
   baseProduct <- shipwire conf $ createProduct cp
   let Right GetProductsResponse {..} = baseProduct
-  let GetProductsResponseResource {..} = gprResource
-  let GetProductsResponseResourceItems {..} = gprrItems
-  let GetProductsResponseResourceItem {..} = last gprriItems
-  let pwBaseProduct@(PwBaseProduct x) = gprriResource
-  let productId = unId $ bprId $ unwrapBaseProduct pwBaseProduct
+      GetProductsResponseResource {..} = gprResource
+      GetProductsResponseResourceItems {..} = gprrItems
+      GetProductsResponseResourceItem {..} = last gprriItems
+      pwBaseProduct@(PwBaseProduct x) = gprriResource
+      productId = unId $ bprId $ unwrapBaseProduct pwBaseProduct
   return (baseProduct, productId)
 
 unwrapBaseProduct :: ProductsWrapper -> BaseProductResponseResource
@@ -589,9 +589,9 @@ main = do
         receivingsResponseWarnings `shouldBe` Nothing
         modifiedReceiving <- shipwire config $ getReceiving receivingId
         let Right ReceivingResponse {..} = modifiedReceiving
-        let ReceivingsItemResource {..} = receivingResponseResource
-        let ItemResourceShipFrom {..} = rirShipFrom
-        let ItemResourceShipFromResource {..} = irsfResource
+            ReceivingsItemResource {..} = receivingResponseResource
+            ItemResourceShipFrom {..} = rirShipFrom
+            ItemResourceShipFromResource {..} = irsfResource
         irsfrCountry `shouldBe` Just (Country "Modified Country")
 
     describe "cancel a receiving" $ do

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -146,7 +146,7 @@ main = do
     describe "get receivings" $ do
       it "gets an itemized list of receivings with optional args" $ do
         result <- shipwire config $ getReceivings -&- (ExpandReceivingsParam [ExpandAll])
-                                                  -&- (StatusParams [StatusCanceled])
+                                                  -&- (ReceivingStatusParams [StatusCanceled])
                                                   -&- (WarehouseIdParam ["TEST 1"])
         result `shouldSatisfy` isRight
 
@@ -253,3 +253,11 @@ main = do
         let Right GetReceivingLabelsResponse {..} = result
         grlrWarnings `shouldBe` Nothing
         grlrErrors `shouldBe` Nothing
+
+    describe "get an itemized list of products" $ do
+      it "gets an itemized list of products" $ do
+        result <- shipwire config $ getProducts -&- (ExpandProductsParam [ExpandEnqueuedDimensions])
+        result `shouldSatisfy` isRight
+        let Right GetProductsResponse {..} = result
+        gprWarnings `shouldBe` Nothing
+        gprErrors `shouldBe` Nothing


### PR DESCRIPTION
This adds the necessary functionality to get back a list of
products.

For some reason the documentation for this endpoint is more
sparse than before. There is no model schema so certain
JSON objects are impossible to understand.

It was also not specified which fields might return "null",
I've had to test and see manually.

There is one point of interest over here:
```
data ProductsWrapper = PwBaseProduct BaseProductResource
  | PwMarketingInsert MarketingInsertResource  
  | PwVirtualKit VirtualKitResource
  | PwKit KitResource
  deriving (Eq, Show)

instance FromJSON ProductsWrapper where
  parseJSON (Object v) = piwValue
    where
      isBaseProduct     = HM.lookup "classification" v == Just "baseProduct"
      isMarketingInsert = HM.lookup "classification" v == Just "marketingInsert"
      isVirtualKit      = HM.lookup "classification" v == Just "virtualKit"
      isKit             = HM.lookup "classification" v == Just "kit"
      piwValue          = parseProductsWrapper isBaseProduct isMarketingInsert isVirtualKit isKit v
  parseJSON _ = mempty

parseProductsWrapper :: Bool -> Bool -> Bool -> Bool -> Object -> Parser ProductsWrapper
parseProductsWrapper isBaseProduct isMarketingInsert isVirtualKit isKit value
  | isBaseProduct     = PwBaseProduct     <$> parseBaseProduct value
  | isMarketingInsert = PwMarketingInsert <$> parseMarketingInsert value
  | isVirtualKit      = PwVirtualKit      <$> parseVirtualKit value
  | isKit             = PwKit             <$> parseKit value
  | otherwise         = PwBaseProduct     <$> parseBaseProduct value
```

Products include 4 possible classifications such as `baseProduct`, `marketingInsert`, `virtualKit`, `kit`. They get returned together in the same array. So here I am checking the `classification` field first and then parse the object based on that. I've modeled it after your [blogpost](http://bitemyapp.com/posts/2014-04-17-parsing-nondeterministic-data-with-aeson-and-sum-types.html) I've stumbled upon.