### PR TITLE
Start implementing order endpoint

### DIFF
--- a/src/Ballast/Client.hs
+++ b/src/Ballast/Client.hs
@@ -201,6 +201,15 @@ retireProducts ptr = request
     url = "/products/retire"
     params = [Body (encode ptr)]
 
+-- | Get an itemized list of orders.
+-- https://www.shipwire.com/w/developers/order/#panel-shipwire0
+getOrders :: ShipwireRequest GetOrdersRequest TupleBS8 BSL.ByteString
+getOrders = request
+  where
+    request = mkShipwireRequest NHTM.methodGet url params
+    url = "/orders"
+    params = []
+
 -- | Create a new order.
 -- https://www.shipwire.com/w/developers/order/#panel-shipwire2
 createOrder :: CreateOrder -> ShipwireRequest CreateOrderRequest TupleBS8 BSL.ByteString

--- a/src/Ballast/Client.hs
+++ b/src/Ballast/Client.hs
@@ -201,6 +201,14 @@ retireProducts ptr = request
     url = "/products/retire"
     params = [Body (encode ptr)]
 
+-- | Create a new order.
+-- https://www.shipwire.com/w/developers/order/#panel-shipwire2
+createOrder :: CreateOrder -> ShipwireRequest CreateOrderRequest TupleBS8 BSL.ByteString
+createOrder co = request
+  where
+    request = mkShipwireRequest NHTM.methodPost url params
+    url = "/orders"
+    params = [Body (encode co)]
 
 -- "{\"status\":401,\"message\":\"Please include a valid Authorization header (Basic)\",\"resourceLocation\":null}"
 

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -3592,19 +3592,19 @@ instance ToJSON KitDimensions where
                                      ,"weight" .= kdWeight]
 
 newtype KitLength = KitLength
-  { unKitLength :: Integer
+  { unKitLength :: Double
   } deriving (Eq, Show, ToJSON)
 
 newtype KitWidth = KitWidth
-  { unKitWidth :: Integer
+  { unKitWidth :: Double
   } deriving (Eq, Show, ToJSON)
 
 newtype KitHeight = KitHeight
-  { unKitHeight :: Integer
+  { unKitHeight :: Double
   } deriving (Eq, Show, ToJSON)
 
 newtype KitWeight = KitWeight
-  { unKitWeight :: Integer
+  { unKitWeight :: Double
   } deriving (Eq, Show, ToJSON)
 
 newtype KitContent = KitContent
@@ -3780,7 +3780,7 @@ instance ToJSON ShouldNotFold where
   toJSON ShouldFold    = Number 0
 
 newtype InsertWhenWorthValue = InsertWhenWorthValue
-  { unInsertWhenWorthValue :: Integer
+  { unInsertWhenWorthValue :: Centi
   } deriving (Eq, Show, ToJSON)
 
 newtype InsertWhenWorthCurrency = InsertWhenWorthCurrency
@@ -3816,19 +3816,19 @@ instance ToJSON MarketingInsertMasterCaseDimensions where
                                                            ,"weight" .= mimcdWeight]
 
 newtype MarketingInsertMasterCaseDimensionsLength = MarketingInsertMasterCaseDimensionsLength
-  { unMarketingInsertMasterCaseDimensionsLength :: Integer
+  { unMarketingInsertMasterCaseDimensionsLength :: Double
   } deriving (Eq, Show, ToJSON)
 
 newtype MarketingInsertMasterCaseDimensionsWidth = MarketingInsertMasterCaseDimensionsWidth
-  { unMarketingInsertMasterCaseDimensionsWidth :: Integer
+  { unMarketingInsertMasterCaseDimensionsWidth :: Double
   } deriving (Eq, Show, ToJSON)
 
 newtype MarketingInsertMasterCaseDimensionsHeight = MarketingInsertMasterCaseDimensionsHeight
-  { unMarketingInsertMasterCaseDimensionsHeight :: Integer
+  { unMarketingInsertMasterCaseDimensionsHeight :: Double
   } deriving (Eq, Show, ToJSON)
 
 newtype MarketingInsertMasterCaseDimensionsWeight = MarketingInsertMasterCaseDimensionsWeight
-  { unMarketingInsertMasterCaseDimensionsWeight :: Integer
+  { unMarketingInsertMasterCaseDimensionsWeight :: Double
   } deriving (Eq, Show, ToJSON)
 
 data BaseProduct = BaseProduct
@@ -4011,19 +4011,19 @@ instance ToJSON BaseProductDimensions where
                                              ,"weight" .= bpdWeight]
 
 newtype BaseProductLength = BaseProductLength
-  { unBaseProductLength :: Integer
+  { unBaseProductLength :: Double
   } deriving (Eq, Show, ToJSON)
 
 newtype BaseProductWidth = BaseProductWidth
-  { unBaseProductWidth :: Integer
+  { unBaseProductWidth :: Double
   } deriving (Eq, Show, ToJSON)
 
 newtype BaseProductHeight = BaseProductHeight
-  { unBaseProductHeight :: Integer
+  { unBaseProductHeight :: Double
   } deriving (Eq, Show, ToJSON)
 
 newtype BaseProductWeight = BaseProductWeight
-  { unBaseProductWeight :: Integer
+  { unBaseProductWeight :: Double
   } deriving (Eq, Show, ToJSON)
 
 newtype SkusParam = SkusParam
@@ -5330,11 +5330,11 @@ newtype CostValueResponse = CostValueResponse
   } deriving (Eq, Show, FromJSON)
 
 newtype CostValue = CostValue
-  { unCostValue :: Integer
+  { unCostValue :: Centi
   } deriving (Eq, Show, ToJSON)
 
 newtype WholesaleValue = WholesaleValue
-  { unWholesaleValue :: Integer
+  { unWholesaleValue :: Centi
   } deriving (Eq, Show, ToJSON)
 
 newtype WholesaleValueResponse = WholesaleValueResponse
@@ -5342,7 +5342,7 @@ newtype WholesaleValueResponse = WholesaleValueResponse
   } deriving (Eq, Show, FromJSON)
 
 newtype RetailValue = RetailValue
-  { unRetailValue :: Integer
+  { unRetailValue :: Centi
   } deriving (Eq, Show, ToJSON)
 
 newtype RetailValueResponse = RetailValueResponse

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -171,14 +171,14 @@ module Ballast.Types
   , UpdatedAfter(..)
   , ReceivingStatusParams(..)
   , ReceivingStatusParam(..)
-  , statusParamToTx
+  , statusParamToBS8
   , OrderNoParam(..)
   , OrderIdParam(..)
   , ExternalIdParam(..)
   , TransactionIdParam(..)
   , ExpandReceivingsParam(..)
   , ExpandReceivings(..)
-  , expandReceivingsToTx
+  , expandReceivingsToBS8
   , CommerceNameParam(..)
   , CreateReceivingResponse
   , GetReceivingsResponse
@@ -420,7 +420,7 @@ module Ballast.Types
   , KitResponseContent
   , ExpandProductsParam(..)
   , ExpandProducts(..)
-  , expandProductsToTx
+  , expandProductsToBS8
   , ClassificationParam(..)
   , classificationToBS
   , DescriptionParam(..)
@@ -2072,19 +2072,19 @@ data ReceivingStatusParam = StatusProcessed
   | StatusTracked
   deriving (Eq, Show)
 
-statusParamToTx :: ReceivingStatusParam -> Text
-statusParamToTx StatusProcessed = "processed"
-statusParamToTx StatusCanceled  = "canceled"
-statusParamToTx StatusCompleted = "completed"
-statusParamToTx StatusDelivered = "delivered"
-statusParamToTx StatusReturned  = "returned"
-statusParamToTx StatusSubmitted = "submitted"
-statusParamToTx StatusHeld      = "held"
-statusParamToTx StatusTracked   = "tracked"
+statusParamToBS8 :: ReceivingStatusParam -> BS8.ByteString
+statusParamToBS8 StatusProcessed = "processed"
+statusParamToBS8 StatusCanceled  = "canceled"
+statusParamToBS8 StatusCompleted = "completed"
+statusParamToBS8 StatusDelivered = "delivered"
+statusParamToBS8 StatusReturned  = "returned"
+statusParamToBS8 StatusSubmitted = "submitted"
+statusParamToBS8 StatusHeld      = "held"
+statusParamToBS8 StatusTracked   = "tracked"
 
 instance ToShipwireParam ReceivingStatusParams where
   toShipwireParam (ReceivingStatusParams xs) =
-    (Query ("status", TE.encodeUtf8 (T.intercalate "," (map statusParamToTx xs))) :)
+    (Query ("status", (BS8.intercalate "," (map statusParamToBS8 xs))) :)
 
 newtype OrderNoParam = OrderNoParam
   { orderNoParam :: [Text]
@@ -2131,18 +2131,18 @@ data ExpandReceivings = ExpandHolds
   | ExpandAll
   deriving (Eq, Show)
 
-expandReceivingsToTx :: ExpandReceivings -> Text
-expandReceivingsToTx ExpandHolds                  = "holds"
-expandReceivingsToTx ExpandInstructionsRecipients = "instructionsRecipients"
-expandReceivingsToTx ExpandItems                  = "items"
-expandReceivingsToTx ExpandShipments              = "shipments"
-expandReceivingsToTx ExpandLabels                 = "labels"
-expandReceivingsToTx ExpandTrackings              = "trackings"
-expandReceivingsToTx ExpandAll                    = "all"
+expandReceivingsToBS8 :: ExpandReceivings -> BS8.ByteString
+expandReceivingsToBS8 ExpandHolds                  = "holds"
+expandReceivingsToBS8 ExpandInstructionsRecipients = "instructionsRecipients"
+expandReceivingsToBS8 ExpandItems                  = "items"
+expandReceivingsToBS8 ExpandShipments              = "shipments"
+expandReceivingsToBS8 ExpandLabels                 = "labels"
+expandReceivingsToBS8 ExpandTrackings              = "trackings"
+expandReceivingsToBS8 ExpandAll                    = "all"
 
 instance ToShipwireParam ExpandReceivingsParam where
   toShipwireParam (ExpandReceivingsParam xs) =
-    (Query ("expand", TE.encodeUtf8 (T.intercalate "," (map expandReceivingsToTx xs))) :)
+    (Query ("expand", (BS8.intercalate "," (map expandReceivingsToBS8 xs))) :)
 
 newtype CommerceNameParam = CommerceNameParam
   { commerceNameParam :: [Text]
@@ -4257,24 +4257,24 @@ data ExpandProducts = ProductsExpandAll
   | ExpandVirtualKitContent
   deriving (Eq, Show)
 
-expandProductsToTx :: ExpandProducts -> Text
-expandProductsToTx ProductsExpandAll        = "all"
-expandProductsToTx ExpandAlternateNames     = "alternateNames"
-expandProductsToTx ExpandMasterCase         = "masterCase"
-expandProductsToTx ExpandEnqueuedDimensions = "enqueuedDimensions"
-expandProductsToTx ExpandFlags              = "flags"
-expandProductsToTx ExpandDimensions         = "dimensions"
-expandProductsToTx ExpandTechnicalData      = "technicalData"
-expandProductsToTx ExpandInnerPack          = "innerPack"
-expandProductsToTx ExpandPallet             = "pallet"
-expandProductsToTx ExpandValues             = "values"
-expandProductsToTx ExpandKitContent         = "kitContent"
-expandProductsToTx ExpandInclusionRules     = "inclusionRules"
-expandProductsToTx ExpandVirtualKitContent  = "virtualKitContent"
+expandProductsToBS8 :: ExpandProducts -> BS8.ByteString
+expandProductsToBS8 ProductsExpandAll        = "all"
+expandProductsToBS8 ExpandAlternateNames     = "alternateNames"
+expandProductsToBS8 ExpandMasterCase         = "masterCase"
+expandProductsToBS8 ExpandEnqueuedDimensions = "enqueuedDimensions"
+expandProductsToBS8 ExpandFlags              = "flags"
+expandProductsToBS8 ExpandDimensions         = "dimensions"
+expandProductsToBS8 ExpandTechnicalData      = "technicalData"
+expandProductsToBS8 ExpandInnerPack          = "innerPack"
+expandProductsToBS8 ExpandPallet             = "pallet"
+expandProductsToBS8 ExpandValues             = "values"
+expandProductsToBS8 ExpandKitContent         = "kitContent"
+expandProductsToBS8 ExpandInclusionRules     = "inclusionRules"
+expandProductsToBS8 ExpandVirtualKitContent  = "virtualKitContent"
 
 instance ToShipwireParam ExpandProductsParam where
   toShipwireParam (ExpandProductsParam xs) =
-    (Query ("expand", TE.encodeUtf8 (T.intercalate "," (map expandProductsToTx xs))) :)
+    (Query ("expand", (BS8.intercalate "," (map expandProductsToBS8 xs))) :)
 
 data GetProductsResponse = GetProductsResponse
   { gprStatus           :: ResponseStatus

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -2164,10 +2164,10 @@ instance FromJSON ItemResourceInstructionsRecipients where
 
 data ItemResourceInstructionsRecipientsResource = ItemResourceInstructionsRecipientsResource
   { irirrItems    :: ItemResourceInstructionsRecipientsResourceItems
-  , irirrNext     :: Maybe Next
-  , irirrOffset   :: Offset
-  , irirrPrevious :: Maybe Previous
-  , irirrTotal    :: Total
+  , irirrNext     :: Maybe ResponseNext
+  , irirrOffset   :: ResponseOffset
+  , irirrPrevious :: Maybe ResponsePrevious
+  , irirrTotal    :: ResponseTotal
   } deriving (Eq, Show)
 
 instance FromJSON ItemResourceInstructionsRecipientsResource where
@@ -2419,10 +2419,10 @@ instance FromJSON ItemResourceLabels where
 
 data ItemResourceLabelsResource = ItemResourceLabelsResource
   { irlrItems    :: ItemResourceLabelsResourceItems
-  , irlrNext     :: Maybe Next
-  , irlrOffset   :: Offset
-  , irlrPrevious :: Maybe Previous
-  , irlrTotal    :: Total
+  , irlrNext     :: Maybe ResponseNext
+  , irlrOffset   :: ResponseOffset
+  , irlrPrevious :: Maybe ResponsePrevious
+  , irlrTotal    :: ResponseTotal
   } deriving (Eq, Show)
 
 instance FromJSON ItemResourceLabelsResource where
@@ -2489,10 +2489,10 @@ instance FromJSON ItemResourceShipments where
 
 data ItemResourceShipmentsResource = ItemResourceShipmentsResource
   { irsrItems    :: ItemResourceShipmentsResourceItems
-  , irsrNext     :: Maybe Next
-  , irsrOffset   :: Offset
-  , irsrPrevious :: Maybe Previous
-  , irsrTotal    :: Total
+  , irsrNext     :: Maybe ResponseNext
+  , irsrOffset   :: ResponseOffset
+  , irsrPrevious :: Maybe ResponsePrevious
+  , irsrTotal    :: ResponseTotal
   } deriving (Eq, Show)
 
 instance FromJSON ItemResourceShipmentsResource where
@@ -2573,10 +2573,10 @@ instance FromJSON ItemResourceTrackings where
 
 data ItemResourceTrackingsResource = ItemResourceTrackingsResource
   { irtrItems    :: ItemResourceTrackingsResourceItems
-  , irtrNext     :: Maybe Next
-  , irtrOffset   :: Offset
-  , irtrPrevious :: Maybe Previous
-  , irtrTotal    :: Total
+  , irtrNext     :: Maybe ResponseNext
+  , irtrOffset   :: ResponseOffset
+  , irtrPrevious :: Maybe ResponsePrevious
+  , irtrTotal    :: ResponseTotal
   } deriving (Eq, Show)
 
 instance FromJSON ItemResourceTrackingsResource where
@@ -2665,10 +2665,10 @@ instance FromJSON ItemResourceItems where
 
 data ItemResourceItemsResource = ItemResourceItemsResource
   { irirItems    :: ItemResourceItemsResourceItems
-  , irirNext     :: Maybe Next
-  , irirOffset   :: Offset
-  , irirPrevious :: Maybe Previous
-  , irirTotal    :: Total
+  , irirNext     :: Maybe ResponseNext
+  , irirOffset   :: ResponseOffset
+  , irirPrevious :: Maybe ResponsePrevious
+  , irirTotal    :: ResponseTotal
   } deriving (Eq, Show)
 
 instance FromJSON ItemResourceItemsResource where
@@ -2753,10 +2753,10 @@ instance FromJSON ItemResourceHolds where
 
 data ItemResourceHoldsResource = ItemResourceHoldsResource
   { irhrItems    :: ItemResourceHoldsResourceItems
-  , irhrNext     :: Maybe Next
-  , irhrOffset   :: Offset
-  , irhrPrevious :: Maybe Previous
-  , irhrTotal    :: Total
+  , irhrNext     :: Maybe ResponseNext
+  , irhrOffset   :: ResponseOffset
+  , irhrPrevious :: Maybe ResponsePrevious
+  , irhrTotal    :: ResponseTotal
   } deriving (Eq, Show)
 
 instance FromJSON ItemResourceHoldsResource where
@@ -4196,10 +4196,10 @@ instance FromJSON GetProductsResponse where
                 <*> o .:? "errors"
 
 data GetProductsResponseResource = GetProductsResponseResource
-  { gprrPrevious :: Maybe Previous
-  , gprrNext     :: Maybe Next
-  , gprrTotal    :: Total
-  , gprrOffset   :: Offset
+  { gprrPrevious :: Maybe ResponsePrevious
+  , gprrNext     :: Maybe ResponseNext
+  , gprrTotal    :: ResponseTotal
+  , gprrOffset   :: ResponseOffset
   , gprrItems    :: GetProductsResponseResourceItems
   } deriving (Eq, Show)
 
@@ -4388,10 +4388,10 @@ instance FromJSON VirtualKitResponseContent where
                 <*> o .:? "resource"
 
 data VirtualKitContentResource = VirtualKitContentResource
-  { vkcrOffset   :: Offset
-  , vkcrTotal    :: Total
-  , vkcrPrevious :: Maybe Previous
-  , vkcrNext     :: Maybe Next
+  { vkcrOffset   :: ResponseOffset
+  , vkcrTotal    :: ResponseTotal
+  , vkcrPrevious :: Maybe ResponsePrevious
+  , vkcrNext     :: Maybe ResponseNext
   , vkcrItems    :: VirtualKitContentResourceItems
   } deriving (Eq, Show)
 
@@ -5022,11 +5022,11 @@ instance FromJSON AlternateNamesResponse where
                 <*> o .:? "resource"
 
 data AlternateNamesResponseResource = AlternateNamesResponseResource
-  { anrPrevious :: Maybe Previous
-  , anrNext     :: Maybe Next
-  , anrTotal    :: Total
+  { anrPrevious :: Maybe ResponsePrevious
+  , anrNext     :: Maybe ResponseNext
+  , anrTotal    :: ResponseTotal
   , anrItems    :: AlternateNamesResponseResourceItems
-  , anrOffset   :: Offset
+  , anrOffset   :: ResponseOffset
   } deriving (Eq, Show)
 
 instance FromJSON AlternateNamesResponseResource where
@@ -5110,13 +5110,13 @@ instance FromJSON EnqueuedDimensions where
                 <*> o .:? "resource"
 
 data EnqueuedDimensionsResource = EnqueuedDimensionsResource
-  { edrPrevious :: Maybe Previous
-  , edrNext     :: Maybe Next
-  , edrTotal    :: Total
+  { edrPrevious :: Maybe ResponsePrevious
+  , edrNext     :: Maybe ResponseNext
+  , edrTotal    :: ResponseTotal
   -- No idea what edrItems are supposed to be.
   -- There is nothing in the API docs and no model schema either.
   , edrItems    :: Maybe Array
-  , edrOffset   :: Offset
+  , edrOffset   :: ResponseOffset
   } deriving (Eq, Show)
 
 instance FromJSON EnqueuedDimensionsResource where

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -11,13 +11,12 @@ import qualified Data.Text as T
 import           Data.Time.Clock (UTCTime)
 import           Test.Hspec
 import           Test.Hspec.Expectations.Contrib (isRight)
--- isLeft,
 
 mkGetRate :: RateOptions -> RateOrder -> GetRate
 mkGetRate ropts rord = GetRate ropts rord
 
 exampleItems :: Items
-exampleItems = [ItemInfo ((SKU "HspecTest3"), Quantity 5)]
+exampleItems = [ItemInfo ((SKU "HspecTest4"), Quantity 5)]
 
 exampleShipTo :: ShipTo
 exampleShipTo =
@@ -47,7 +46,7 @@ exampleCreateReceiving =
        [ReceivingShipment Nothing Nothing Nothing Nothing $ Type "box"])
     Nothing
     Nothing
-    (ReceivingItems [ReceivingItem (SKU "HspecTest3") (Quantity 3)])
+    (ReceivingItems [ReceivingItem (SKU "HspecTest4") (Quantity 3)])
     (ReceivingShipFrom
        Nothing
        (Name "Stephen Alexander")
@@ -103,7 +102,7 @@ exampleModifiedReceiving =
        [ReceivingShipment Nothing Nothing Nothing Nothing $ Type "box"])
     Nothing
     Nothing
-    (ReceivingItems [ReceivingItem (SKU "HspecTest3") (Quantity 3)])
+    (ReceivingItems [ReceivingItem (SKU "HspecTest4") (Quantity 3)])
     (ReceivingShipFrom
        Nothing
        (Name "Stephen Alexander")
@@ -412,8 +411,8 @@ exampleModifyProducts productId =
   [ CpwBaseProduct $
     BaseProduct
       (Just $ Id productId)
-      (SKU "HspecTest3")
-      (Just $ ExternalId "hspectest3")
+      (SKU "HspecTest4")
+      (Just $ ExternalId "hspectest4")
       (BaseProductClassification)
       (Description "Modified description")
       (Just $ HsCode "010612")
@@ -427,7 +426,7 @@ exampleModifyProducts productId =
          (Just $ CostCurrency "USD")
          (Just $ WholesaleCurrency "USD")
          (Just $ RetailCurrency "USD"))
-      (BaseProductAlternateNames [BaseProductAlternateName (Name "HspecAlt3")])
+      (BaseProductAlternateNames [BaseProductAlternateName (Name "HspecAlt4")])
       (BaseProductDimensions
          (BaseProductLength 10)
          (BaseProductWidth 10)
@@ -454,9 +453,9 @@ exampleModifyProducts productId =
          HasPallet)
       (BaseProductInnerPack
          (IndividualItemsPerCase 2)
-         (Just $ ExternalId "narp55")
-         (SKU "singleInner3")
-         (Description "InnerDesc3")
+         (Just $ ExternalId "narp6")
+         (SKU "singleInner4")
+         (Description "InnerDesc4")
          (Values
             (CostValue 1)
             (WholesaleValue 2)
@@ -472,9 +471,9 @@ exampleModifyProducts productId =
          (BaseProductInnerPackFlags NotPackagedReadyToShip))
       (BaseProductMasterCase
          (IndividualItemsPerCase 10)
-         (Just $ ExternalId "narp66")
-         (SKU "singleMaster4")
-         (Description "masterdesc4")
+         (Just $ ExternalId "narp7")
+         (SKU "singleMaster5")
+         (Description "masterdesc5")
          (Values
             (CostValue 1)
             (WholesaleValue 2)
@@ -490,9 +489,9 @@ exampleModifyProducts productId =
          (BaseProductMasterCaseFlags PackagedReadyToShip))
       (BaseProductPallet
          (IndividualItemsPerCase 1000)
-         (Just $ ExternalId "narp77")
-         (SKU "singlePallet3")
-         (Description "palletdesc3")
+         (Just $ ExternalId "narp8")
+         (SKU "singlePallet4")
+         (Description "palletdesc4")
          (Values
             (CostValue 1)
             (WholesaleValue 2)
@@ -513,8 +512,8 @@ exampleModifyProduct productId =
   CpwBaseProduct $
     BaseProduct
       (Just $ Id productId)
-      (SKU "HspecTest3")
-      (Just $ ExternalId "hspectest3")
+      (SKU "HspecTest4")
+      (Just $ ExternalId "hspectest4")
       (BaseProductClassification)
       (Description "Modified description")
       (Just $ HsCode "010612")
@@ -528,7 +527,7 @@ exampleModifyProduct productId =
          (Just $ CostCurrency "USD")
          (Just $ WholesaleCurrency "USD")
          (Just $ RetailCurrency "USD"))
-      (BaseProductAlternateNames [BaseProductAlternateName (Name "HspecAlt3")])
+      (BaseProductAlternateNames [BaseProductAlternateName (Name "HspecAlt4")])
       (BaseProductDimensions
          (BaseProductLength 10)
          (BaseProductWidth 10)
@@ -555,9 +554,9 @@ exampleModifyProduct productId =
          HasPallet)
       (BaseProductInnerPack
          (IndividualItemsPerCase 2)
-         (Just $ ExternalId "narp55")
-         (SKU "singleInner3")
-         (Description "InnerDesc3")
+         (Just $ ExternalId "narp6")
+         (SKU "singleInner4")
+         (Description "InnerDesc4")
          (Values
             (CostValue 1)
             (WholesaleValue 2)
@@ -573,9 +572,9 @@ exampleModifyProduct productId =
          (BaseProductInnerPackFlags NotPackagedReadyToShip))
       (BaseProductMasterCase
          (IndividualItemsPerCase 10)
-         (Just $ ExternalId "narp66")
-         (SKU "singleMaster4")
-         (Description "masterdesc4")
+         (Just $ ExternalId "narp7")
+         (SKU "singleMaster5")
+         (Description "masterdesc5")
          (Values
             (CostValue 1)
             (WholesaleValue 2)
@@ -591,9 +590,9 @@ exampleModifyProduct productId =
          (BaseProductMasterCaseFlags PackagedReadyToShip))
       (BaseProductPallet
          (IndividualItemsPerCase 1000)
-         (Just $ ExternalId "narp77")
-         (SKU "singlePallet3")
-         (Description "palletdesc3")
+         (Just $ ExternalId "narp8")
+         (SKU "singlePallet4")
+         (Description "palletdesc4")
          (Values
             (CostValue 1)
             (WholesaleValue 2)
@@ -613,10 +612,10 @@ exampleCreateBaseProduct =
   [ CpwBaseProduct $
     BaseProduct
       Nothing
-      (SKU "HspecTest3")
-      (Just $ ExternalId "hspectest3")
+      (SKU "HspecTest4")
+      (Just $ ExternalId "hspectest4")
       (BaseProductClassification)
-      (Description "Hspec test product3")
+      (Description "Hspec test product4")
       (Just $ HsCode "010612")
       (Just $ CountryOfOrigin "US")
       (Category "TOYS_SPORTS_HOBBIES")
@@ -628,7 +627,7 @@ exampleCreateBaseProduct =
          (Just $ CostCurrency "USD")
          (Just $ WholesaleCurrency "USD")
          (Just $ RetailCurrency "USD"))
-      (BaseProductAlternateNames [BaseProductAlternateName (Name "HspecAlt3")])
+      (BaseProductAlternateNames [BaseProductAlternateName (Name "HspecAlt5")])
       (BaseProductDimensions
          (BaseProductLength 10)
          (BaseProductWidth 10)
@@ -655,9 +654,9 @@ exampleCreateBaseProduct =
          HasPallet)
       (BaseProductInnerPack
          (IndividualItemsPerCase 2)
-         (Just $ ExternalId "narp55")
-         (SKU "singleInner3")
-         (Description "InnerDesc3")
+         (Just $ ExternalId "narp6")
+         (SKU "singleInner4")
+         (Description "InnerDesc4")
          (Values
             (CostValue 1)
             (WholesaleValue 2)
@@ -673,9 +672,9 @@ exampleCreateBaseProduct =
          (BaseProductInnerPackFlags NotPackagedReadyToShip))
       (BaseProductMasterCase
          (IndividualItemsPerCase 10)
-         (Just $ ExternalId "narp66")
-         (SKU "singleMaster4")
-         (Description "masterdesc4")
+         (Just $ ExternalId "narp7")
+         (SKU "singleMaster5")
+         (Description "masterdesc5")
          (Values
             (CostValue 1)
             (WholesaleValue 2)
@@ -691,9 +690,9 @@ exampleCreateBaseProduct =
          (BaseProductMasterCaseFlags PackagedReadyToShip))
       (BaseProductPallet
          (IndividualItemsPerCase 1000)
-         (Just $ ExternalId "narp77")
-         (SKU "singlePallet3")
-         (Description "palletdesc3")
+         (Just $ ExternalId "narp8")
+         (SKU "singlePallet4")
+         (Description "palletdesc4")
          (Values
             (CostValue 1)
             (WholesaleValue 2)
@@ -887,7 +886,7 @@ main = do
     describe "get rates" $ do
       it "gets the correct rates" $ do
         (_, productId) <- createBaseProductHelper config exampleCreateBaseProduct
-        let getRt = mkGetRate (RateOptions USD GroupByAll Nothing Nothing Nothing (Just IgnoreUnknownSkus) (CanSplit 1) WarehouseAreaUS Nothing) (RateOrder exampleShipTo exampleItems)
+        let getRt = mkGetRate (RateOptions USD GroupByAll Nothing Nothing Nothing (Just IgnoreUnknownSkus) CanSplit WarehouseAreaUS Nothing) (RateOrder exampleShipTo exampleItems)
         result <- shipwire config $ createRateRequest getRt
         result `shouldSatisfy` isRight
         _ <- shipwire config $ retireProducts $ ProductsToRetire [ProductId productId]

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -761,8 +761,8 @@ exampleOrder =
       (Name "Test Person")
       (Company "Best Company")
       (AddressLine "First line")
-      (AddressLine "Second line 25")
-      (AddressLine "")
+      (Just $ AddressLine "Second line 25")
+      (Just $ AddressLine "")
       (City "Best city")
       (State "WA")
       (PostalCode "100100")
@@ -773,7 +773,7 @@ exampleOrder =
     )
     Nothing
     Nothing
-    (OrderItems [OrderItem (Just $ CommercialInvoiceValue 4.5) (Just $ CommercialInvoiceValueCurrency "USD") (Quantity 5) (SKU "HspecTest3")])
+    (OrderItems [OrderItem (Just $ CommercialInvoiceValue 4.5) (Just $ CommercialInvoiceValueCurrency "USD") (Quantity 5) (SKU "HspecTest4")])
 
 createReceivingHelper :: ShipwireConfig -> CreateReceiving -> IO (Either ShipwireError (ShipwireReturn CreateReceivingRequest), ReceivingId)
 createReceivingHelper conf cr = do
@@ -1134,3 +1134,15 @@ main = do
         result <- shipwire config $ createOrder exampleOrder
         _ <- shipwire config $ retireProducts $ ProductsToRetire [ProductId productId]
         result `shouldSatisfy` isRight
+        let Right GetOrdersResponse {..} = result
+        gorWarnings `shouldBe` Nothing
+        gorErrors `shouldBe` Nothing
+
+    describe "get orders" $ do
+      it "gets all the orders" $ do
+        result <- shipwire config $ getOrders -&- ExpandOrdersParam [OrdersExpandAll]
+                                              -&- OrderStatusParam [OrderCanceled]
+        result `shouldSatisfy` isRight
+        let Right GetOrdersResponse {..} = result
+        gorWarnings `shouldBe` Nothing
+        gorErrors `shouldBe` Nothing

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -748,6 +748,34 @@ exampleCreateMarketingInsert = [CpwMarketingInsert $ MarketingInsert
                           )
                         ]
 
+exampleOrder :: CreateOrder
+exampleOrder =
+  CreateOrder
+    Nothing
+    (Just $ OrderNo "testorder6")
+    Nothing
+    Nothing
+    Nothing
+    Nothing
+    (OrderShipTo
+      (Email "test@example.com")
+      (Name "Test Person")
+      (Company "Best Company")
+      (AddressLine "First line")
+      (AddressLine "Second line 25")
+      (AddressLine "")
+      (City "Best city")
+      (State "WA")
+      (PostalCode "100100")
+      (Country "US")
+      (Phone "6315613729")
+      NotCommercial
+      NotPoBox
+    )
+    Nothing
+    Nothing
+    (OrderItems [OrderItem (Just $ CommercialInvoiceValue 4.5) (Just $ CommercialInvoiceValueCurrency "USD") (Quantity 5) (SKU "HspecTest3")])
+
 createReceivingHelper :: ShipwireConfig -> CreateReceiving -> IO (Either ShipwireError (ShipwireReturn CreateReceivingRequest), ReceivingId)
 createReceivingHelper conf cr = do
   receiving <- shipwire conf $ createReceiving cr
@@ -1100,3 +1128,10 @@ main = do
             status@Status {..} = miiStatus
         result `shouldSatisfy` isRight
         status `shouldBe` Status "deprecated"
+
+    describe "create an order" $ do
+      it "creates an order" $ do
+        (_, productId) <- createBaseProductHelper config exampleCreateBaseProduct        
+        result <- shipwire config $ createOrder exampleOrder
+        _ <- shipwire config $ retireProducts $ ProductsToRetire [ProductId productId]
+        result `shouldSatisfy` isRight


### PR DESCRIPTION
This adds the following functions:

```
GET /api/v3/orders
Get an itemized list of orders.
```

and

```
POST /api/v3/orders
Create a new order.
```

I'll add this one next:

```
GET /api/v3/orders/{id}/trackings or /api/v3/orders/E{externalId}/trackings
Get tracking information for this order.
```

since it has a higher priority and we could probably merge it in so I could switch to address validation. Also, address validation uses `/api/v3.1` and requires you to contact Shipwire in order to use it.

