### PR TITLE
Add POST /api/v3.1/addressValidation

### DIFF
--- a/src/Ballast/Client.hs
+++ b/src/Ballast/Client.hs
@@ -241,6 +241,15 @@ getOrderTrackings idwr = request
       (WrappedExternalId x) -> T.concat ["/orders/E", unExternalId x, "/trackings"]
     params = []
 
+-- | Validate Address
+-- https://www.shipwire.com/w/developers/address-validation
+validateAddress :: AddressToValidate -> ShipwireRequest ValidateAddressRequest TupleBS8 BSL.ByteString
+validateAddress atv = request
+  where
+    request = mkShipwireRequest NHTM.methodPost url params
+    url = ".1/addressValidation"
+    params = [Body (encode atv)]
+
 -- "{\"status\":401,\"message\":\"Please include a valid Authorization header (Basic)\",\"resourceLocation\":null}"
 
 shipwire' :: (FromJSON (ShipwireReturn a))

--- a/src/Ballast/Types.hs
+++ b/src/Ballast/Types.hs
@@ -6974,7 +6974,9 @@ newtype ProcessAfterDate = ProcessAfterDate
 instance ToJSON ProcessAfterDate where
   toJSON (ProcessAfterDate x) = object ["processAfterDate" .= utcToShipwire x]
 
+------------------------------------------------------------------------------------------
 -- Address Validation Endpoint https://www.shipwire.com/w/developers/address-validation --
+------------------------------------------------------------------------------------------
 
 -- | POST /api/v3.1/addressValidation
 data ValidateAddressRequest

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -421,9 +421,9 @@ exampleOrder randomPart productSku =
     )
     Nothing
     (OrderShipTo
-      (Email "test@example.com")
+      (Just $ Email "test@example.com")
       (Name "Test Person")
-      (Company "Best Company")
+      (Just $ Company "Best Company")
       (AddressLine "First line")
       (Just $ AddressLine "Second line 25")
       (Just $ AddressLine "")
@@ -432,12 +432,28 @@ exampleOrder randomPart productSku =
       (Just $ PostalCode "100100")
       (Country "US")
       (Phone "6315613729")
-      NotCommercial
-      NotPoBox
+      (NotCommercial)
+      (Just $ NotPoBox)
     )
     Nothing
     Nothing
     (OrderItems [OrderItem (Just $ CommercialInvoiceValue 4.5) (Just $ CommercialInvoiceValueCurrency "USD") (Quantity 5) (productSku)])
+
+exampleAddress :: AddressToValidate
+exampleAddress = OrderShipTo
+                  (Just $ Email "test@example.com")
+                  (Name "Test Person")
+                  (Just $ Company "My Company")
+                  (AddressLine "3351 Michelson Dr STE 100")
+                  (Nothing)
+                  (Nothing)
+                  (City "Irvine")
+                  (State "CA")
+                  (Just $ PostalCode "92612-0697")
+                  (Country "US")
+                  (Phone "8885551212")
+                  (Commercial)
+                  (Nothing)
 
 createReceivingHelper :: ShipwireConfig -> CreateReceiving -> IO (Either ShipwireError (ShipwireReturn CreateReceivingRequest), ReceivingId)
 createReceivingHelper conf cr = do
@@ -908,3 +924,12 @@ main = do
         let Right GetOrderTrackingsResponse {..} = result
         gotrWarnings `shouldBe` Nothing
         gotrErrors `shouldBe` Nothing
+
+    describe "validate address" $ do
+      it "validates an address" $ do
+        result <- shipwire config $ validateAddress exampleAddress
+        result `shouldSatisfy` isRight
+        let Right ValidateAddressResponse {..} = result
+        varMessage `shouldBe` (ResponseMessage "The address provided is valid")
+        varWarnings `shouldBe` Nothing
+        varErrors `shouldBe` Nothing


### PR DESCRIPTION
This adds address validation functionality. 

The return types are a bit tricky, because at a certain point it's unknown what warnings and errors you'll get. So for now those parts are represented as `aeson`'s `Object` type.